### PR TITLE
Pandas 1.0 Support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -163,7 +163,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies (pandas)
       run: |
-        pip install http://downloads.tableau.com/tssoftware/tableauhyperapi-0.0.9273-py3-none-win_amd64.whl        
+        pip install http://downloads.tableau.com/tssoftware/tableauhyperapi-0.0.9273-py3-none-win_amd64.whl
         pip install --pre pandas==1.0.0rc0
     - name: Build extensions
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -87,3 +87,88 @@ jobs:
       run: |
         pip install pytest
         pytest
+
+  build-linux-rc:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Run code checks
+      run: |
+        python -m pip install --upgrade pip
+        pip install mypy isort black
+        black --check pantab
+        # isort **/*.py -c
+        mypy pantab
+    - name: Install dependencies (pandas)
+      run: |
+        pip install http://downloads.tableau.com/tssoftware/tableauhyperapi-0.0.9273-py3-none-linux_x86_64.whl
+        pip install --pre pandas==1.0.0rc0
+    - name: Build extensions
+      run: |
+        python setup.py build_ext --inplace
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest
+
+  build-macos-rc:
+
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies (pandas)
+      run: |
+        pip install http://downloads.tableau.com/tssoftware/tableauhyperapi-0.0.9273-py3-none-macosx_10_11_x86_64.whl
+        pip install --pre pandas==1.0.0rc0
+    - name: Build extensions
+      run: |
+        python setup.py build_ext --inplace
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest
+
+  build-windows-rc:
+
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies (pandas)
+      run: |
+        pip install http://downloads.tableau.com/tssoftware/tableauhyperapi-0.0.9273-py3-none-win_amd64.whl        
+        pip install --pre pandas==1.0.0rc0
+    - name: Build extensions
+      run: |
+        python setup.py build_ext --inplace
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest

--- a/doc/source/caveats.rst
+++ b/doc/source/caveats.rst
@@ -27,6 +27,8 @@ pantab maps the following dtypes from pandas to the equivalent column type in Ta
 +--------------------+-----------------+------------+
 |bool                |BOOL             |NOT NULLABLE|
 +--------------------+-----------------+------------+
+|boolean             |BOOL             |NULLABLE    |
++--------------------+-----------------+------------+
 |datetime64[ns]      |TIMESTAMP        |NULLABLE    |
 +--------------------+-----------------+------------+
 |datetime64[ns, UTC] |TIMESTAMP_WITH_TZ|Nullable    |
@@ -35,16 +37,17 @@ pantab maps the following dtypes from pandas to the equivalent column type in Ta
 +--------------------+-----------------+------------+
 |object              |TEXT             |NULLABLE    |
 +--------------------+-----------------+------------+
+|string              |TEXT             |NULLABLE    |
++--------------------+-----------------+------------+
 
 Any dtype not explicitly listed in the above table will raise a ValueError if trying to write out data.
 
-.. warning::
-
-   ``object`` dtype is a very generic type in pandas, but is the closest type to a native "text" type available prior to 1.0.0. Passing non-string / NULL data through an ``object`` dtype will raise a TypeError, though it is perfectly valid for storage in pandas. This may change in the future as pandas 1.0.0 introduces a dedicated "String" data type.
+.. versionadded:: 1.0.0
+   If using pandas 1.0 and above, text data will be read back into a ``"string"`` dtype rather than an ``object`` dtype.
 
 .. note::
 
-   All objects can maintain their type when "round-tripping" to/from Hyper extracts, with the exception of the float32 object as only DOUBLE is available for floating point storage in Hyper. 
+   Most objects can maintain their type when "round-tripping" to/from Hyper extracts, with the exception of the float32 object as only DOUBLE is available for floating point storage in Hyper. After pandas 1.0 / pantab 1.0, object dtypes written will be read back in as string.
 
 Missing Value Handling
 ----------------------

--- a/pantab/_compat.py
+++ b/pantab/_compat.py
@@ -1,0 +1,7 @@
+from distutils.version import LooseVersion
+
+import pandas as pd
+
+PANDAS_100 = LooseVersion(pd.__version__) >= LooseVersion("1.0.0")
+
+__all__ = ["PANDAS_100"]

--- a/pantab/_readermodule.c
+++ b/pantab/_readermodule.c
@@ -23,12 +23,14 @@ static PyObject *read_value(const uint8_t *value, DTYPE dtype,
         return PyLong_FromLongLong(*((int64_t *)value));
 
     case BOOLEAN:
+    case BOOLEANNA:
         return PyBool_FromLong(*value);
 
     case FLOAT32_:
     case FLOAT64_:
         return PyFloat_FromDouble(*((double *)value));
 
+    case STRING:
     case OBJECT:
         // TODO: are there any platforms where we cant cast char* and
         // unsigned char* ???

--- a/pantab/_types.py
+++ b/pantab/_types.py
@@ -1,6 +1,8 @@
 import collections
+from distutils.version import LooseVersion
 from typing import Union
 
+import pandas as pd
 import tableauhyperapi as tab_api
 
 # The Hyper API as of writing doesn't offer great hashability for column comparison
@@ -30,6 +32,12 @@ _column_types = {
     ),
     "object": _ColumnType(tab_api.SqlType.text(), tab_api.Nullability.NULLABLE),
 }
+
+if LooseVersion(pd.__version__) >= "1.0.0":
+    _column_types["string"] = _ColumnType(tab_api.SqlType.text(), tab_api.Nullability.NULLABLE)
+    _column_types["boolean"] = _ColumnType(tab_api.SqlType.bool(), tab_api.Nullability.NULLABLE)
+else:
+    _column_types["object"] = _ColumnType(tab_api.SqlType.text(), tab_api.Nullability.NULLABLE)
 
 
 # Invert this, but exclude float32 as that does not roundtrip

--- a/pantab/_types.py
+++ b/pantab/_types.py
@@ -1,9 +1,10 @@
 import collections
-from distutils.version import LooseVersion
 from typing import Union
 
 import pandas as pd
 import tableauhyperapi as tab_api
+
+import pantab._compat as compat
 
 # The Hyper API as of writing doesn't offer great hashability for column comparison
 # so we create out namedtuple for that purpose
@@ -33,7 +34,7 @@ _column_types = {
     "object": _ColumnType(tab_api.SqlType.text(), tab_api.Nullability.NULLABLE),
 }
 
-if LooseVersion(pd.__version__) >= "1.0.0":
+if compat.PANDAS_100:
     _column_types["string"] = _ColumnType(tab_api.SqlType.text(), tab_api.Nullability.NULLABLE)
     _column_types["boolean"] = _ColumnType(tab_api.SqlType.bool(), tab_api.Nullability.NULLABLE)
 else:

--- a/pantab/_types.py
+++ b/pantab/_types.py
@@ -1,7 +1,6 @@
 import collections
 from typing import Union
 
-import pandas as pd
 import tableauhyperapi as tab_api
 
 import pantab._compat as compat
@@ -35,10 +34,16 @@ _column_types = {
 }
 
 if compat.PANDAS_100:
-    _column_types["string"] = _ColumnType(tab_api.SqlType.text(), tab_api.Nullability.NULLABLE)
-    _column_types["boolean"] = _ColumnType(tab_api.SqlType.bool(), tab_api.Nullability.NULLABLE)
+    _column_types["string"] = _ColumnType(
+        tab_api.SqlType.text(), tab_api.Nullability.NULLABLE
+    )
+    _column_types["boolean"] = _ColumnType(
+        tab_api.SqlType.bool(), tab_api.Nullability.NULLABLE
+    )
 else:
-    _column_types["object"] = _ColumnType(tab_api.SqlType.text(), tab_api.Nullability.NULLABLE)
+    _column_types["object"] = _ColumnType(
+        tab_api.SqlType.text(), tab_api.Nullability.NULLABLE
+    )
 
 
 # Invert this, but exclude float32 as that does not roundtrip

--- a/pantab/_writermodule.c
+++ b/pantab/_writermodule.c
@@ -102,20 +102,20 @@ static hyper_error_t *writeNonNullData(PyObject *data, DTYPE dtype,
     }
     case STRING:
     case OBJECT: {
-      if (dtype == OBJECT) {
-	// N.B. all other dtypes in pandas are well defined, but object is
-        // really anything For purposes of Tableau these need to be strings,
-        // so error out if not In the future should enforce StringDtype from
-        // pandas once released (1.0.0)
-        if (!PyUnicode_Check(data)) {
-	  PyObject *errMsg = PyUnicode_FromFormat(
-						  "Invalid value \"%R\" found (row %zd column %zd)", data, row,
-						  col);
-	  PyErr_SetObject(PyExc_TypeError, errMsg);
-	  Py_DECREF(errMsg);
-	  return NULL;
+        if (dtype == OBJECT) {
+            // N.B. all other dtypes in pandas are well defined, but object is
+            // really anything For purposes of Tableau these need to be strings,
+            // so error out if not In the future should enforce StringDtype from
+            // pandas once released (1.0.0)
+            if (!PyUnicode_Check(data)) {
+                PyObject *errMsg = PyUnicode_FromFormat(
+                    "Invalid value \"%R\" found (row %zd column %zd)", data,
+                    row, col);
+                PyErr_SetObject(PyExc_TypeError, errMsg);
+                Py_DECREF(errMsg);
+                return NULL;
+            }
         }
-      }
         Py_ssize_t len;
         // TODO: CPython uses a const char* buffer but Hyper accepts
         // const unsigned char* - is this always safe?

--- a/pantab/newsfragments/20.feature
+++ b/pantab/newsfragments/20.feature
@@ -1,0 +1,5 @@
+pantab now supports reading/writing pandas 1.0 dtypes, namely the ``boolean`` and ``string`` dtypes.
+
+.. important::
+
+   TEXT data read from a Hyper extract will be stored in a ``"string"`` dtype when using pandas 1.0 or greater in combination with pantab 1.0 or greater. Older versions of either tool will read the data back into a ``object`` dtype.

--- a/pantab/pantab.h
+++ b/pantab/pantab.h
@@ -18,10 +18,12 @@ typedef enum {
     FLOAT32_ = 11,
     FLOAT64_,
     BOOLEAN = 50,
+    BOOLEANNA,
     DATETIME64_NS = 100,
     DATETIME64_NS_UTC,
     TIMEDELTA64_NS = 200,
     OBJECT = 220,
+    STRING,
     UNKNOWN = 255
 } DTYPE;
 
@@ -37,9 +39,11 @@ static const struct {
                  {FLOAT32_, "float32"},
                  {FLOAT64_, "float64"},
                  {BOOLEAN, "bool"},
+		 {BOOLEAN, "boolean"},
                  {DATETIME64_NS, "datetime64[ns]"},
                  {DATETIME64_NS_UTC, "datetime64[ns, UTC]"},
                  {TIMEDELTA64_NS, "timedelta64[ns]"},
+		 {STRING, "string"},
                  {OBJECT, "object"}};
 
 // creates an enumeration from a tuple of strings,

--- a/pantab/pantab.h
+++ b/pantab/pantab.h
@@ -2,11 +2,12 @@
 #define PANTAB
 
 #define PY_SSIZE_T_CLEAN
+#include "tableauhyperapi.h"
 #include <Python.h>
 #include <inttypes.h>
-#include "tableauhyperapi.h"
 
-#define MICROSECONDS_PER_DAY (INT64_C(24) * INT64_C(60) * INT64_C(60) * INT64_C(1000000))
+#define MICROSECONDS_PER_DAY                                                   \
+    (INT64_C(24) * INT64_C(60) * INT64_C(60) * INT64_C(1000000))
 
 typedef enum {
     INT16_ = 1,
@@ -39,11 +40,11 @@ static const struct {
                  {FLOAT32_, "float32"},
                  {FLOAT64_, "float64"},
                  {BOOLEAN, "bool"},
-		 {BOOLEAN, "boolean"},
+                 {BOOLEAN, "boolean"},
                  {DATETIME64_NS, "datetime64[ns]"},
                  {DATETIME64_NS_UTC, "datetime64[ns, UTC]"},
                  {TIMEDELTA64_NS, "timedelta64[ns]"},
-		 {STRING, "string"},
+                 {STRING, "string"},
                  {OBJECT, "object"}};
 
 // creates an enumeration from a tuple of strings,

--- a/pantab/tableauhyperapi.h
+++ b/pantab/tableauhyperapi.h
@@ -17,7 +17,9 @@ The original copyright notice is included below for reference.
 #ifndef PANTAB_HYPER_API
 #define PANTAB_HYPER_API
 
+#include <inttypes.h>
 #include <stdbool.h>
+#include <stdio.h>
 
 typedef uint32_t hyper_date_t;
 typedef struct {

--- a/pantab/tests/conftest.py
+++ b/pantab/tests/conftest.py
@@ -21,7 +21,6 @@ def df():
                 4.0,
                 5.0,
                 True,
-                True,
                 pd.to_datetime("2018-01-01"),
                 pd.to_datetime("2018-01-01", utc=True),
                 pd.Timedelta("1 days 2 hours 3 minutes 4 seconds"),
@@ -42,7 +41,6 @@ def df():
                 np.nan,
                 9.0,
                 10.0,
-                False,
                 False,
                 pd.to_datetime("1/1/19"),
                 pd.to_datetime("2019-01-01", utc=True),
@@ -65,11 +63,10 @@ def df():
                 np.nan,
                 np.nan,
                 False,
-                pd.NA,
                 pd.NaT,
                 pd.NaT,
                 pd.NaT,
-                pd.NA if compat.PANDAS_100 else np.nan,
+                np.nan,
                 0,
                 0,
                 0,
@@ -88,11 +85,10 @@ def df():
             "float32",
             "float64",
             "bool",
-            "boolean",
             "datetime64",
             "datetime64_utc",
             "timedelta64",
-            "string" if compat.PANDAS_100 else "object",
+            "object",
             "int16_limits",
             "int32_limits",
             "int64_limits",
@@ -112,25 +108,22 @@ def df():
         "float32": np.float32,
         "float64": np.float64,
         "bool": np.bool,
-        "boolean": "boolean",
         "datetime64": "datetime64[ns]",
         "datetime64_utc": "datetime64[ns, UTC]",
         "timedelta64": "timedelta64[ns]",
+        "object": object,
         "int16_limits": np.int16,
         "int32_limits": np.int32,
         "int64_limits": np.int64,
         "float32_limits": np.float64,
         "float64_limits": np.float64,
+        "non-ascii": object,
     }
 
+    df = df.astype(astypes)    
     if compat.PANDAS_100:
-        astypes["string"] = "string"
-        astypes["non-ascii"] = "string"
-    else:
-        astypes["object"] = object
-        astypes["non-ascii"] = object
-
-    df = df.astype(astypes)
+        df["boolean"] = pd.Series([True, False, pd.NA], dtype="boolean")
+        df["string"] = pd.Series(["foo", "bar", pd.NA], dtype="string")
 
     return df
 

--- a/pantab/tests/conftest.py
+++ b/pantab/tests/conftest.py
@@ -1,7 +1,11 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 import pandas as pd
 import pytest
 import tableauhyperapi as tab_api
+
+PANDAS_100 = LooseVersion(pd.__version__) >= LooseVersion("1.0.0")
 
 
 @pytest.fixture
@@ -18,6 +22,7 @@ def df():
                 3,
                 4.0,
                 5.0,
+                True,
                 True,
                 pd.to_datetime("2018-01-01"),
                 pd.to_datetime("2018-01-01", utc=True),
@@ -40,6 +45,7 @@ def df():
                 9.0,
                 10.0,
                 False,
+                False,
                 pd.to_datetime("1/1/19"),
                 pd.to_datetime("2019-01-01", utc=True),
                 pd.Timedelta("-1 days 2 hours 3 minutes 4 seconds"),
@@ -61,10 +67,11 @@ def df():
                 np.nan,
                 np.nan,
                 False,
+                pd.NA,
                 pd.NaT,
                 pd.NaT,
                 pd.NaT,
-                np.nan,
+                pd.NA if PANDAS_100 else np.nan,
                 0,
                 0,
                 0,
@@ -83,10 +90,11 @@ def df():
             "float32",
             "float64",
             "bool",
+            "boolean",
             "datetime64",
             "datetime64_utc",
             "timedelta64",
-            "object",
+            "string" if PANDAS_100 else "object",
             "int16_limits",
             "int32_limits",
             "int64_limits",
@@ -96,8 +104,7 @@ def df():
         ],
     )
 
-    df = df.astype(
-        {
+    astypes = {
             "int16": np.int16,
             "Int16": "Int16",
             "int32": np.int32,
@@ -107,18 +114,25 @@ def df():
             "float32": np.float32,
             "float64": np.float64,
             "bool": np.bool,
+            "boolean": "boolean",
             "datetime64": "datetime64[ns]",
             "datetime64_utc": "datetime64[ns, UTC]",
             "timedelta64": "timedelta64[ns]",
-            "object": "object",
             "int16_limits": np.int16,
             "int32_limits": np.int32,
             "int64_limits": np.int64,
             "float32_limits": np.float64,
             "float64_limits": np.float64,
-            "non-ascii": "object",
         }
-    )
+
+    if PANDAS_100:
+        astypes["string"] = "string"
+        astypes["non-ascii"] = "string"
+    else:
+        astypes["object"] = object
+        astypes["non-ascii"] = object
+
+    df = df.astype(astypes)
 
     return df
 

--- a/pantab/tests/conftest.py
+++ b/pantab/tests/conftest.py
@@ -1,11 +1,9 @@
-from distutils.version import LooseVersion
-
 import numpy as np
 import pandas as pd
 import pytest
 import tableauhyperapi as tab_api
 
-PANDAS_100 = LooseVersion(pd.__version__) >= LooseVersion("1.0.0")
+import pantab._compat as compat
 
 
 @pytest.fixture
@@ -71,7 +69,7 @@ def df():
                 pd.NaT,
                 pd.NaT,
                 pd.NaT,
-                pd.NA if PANDAS_100 else np.nan,
+                pd.NA if compat.PANDAS_100 else np.nan,
                 0,
                 0,
                 0,
@@ -94,7 +92,7 @@ def df():
             "datetime64",
             "datetime64_utc",
             "timedelta64",
-            "string" if PANDAS_100 else "object",
+            "string" if compat.PANDAS_100 else "object",
             "int16_limits",
             "int32_limits",
             "int64_limits",
@@ -125,7 +123,7 @@ def df():
             "float64_limits": np.float64,
         }
 
-    if PANDAS_100:
+    if compat.PANDAS_100:
         astypes["string"] = "string"
         astypes["non-ascii"] = "string"
     else:

--- a/pantab/tests/conftest.py
+++ b/pantab/tests/conftest.py
@@ -120,7 +120,7 @@ def df():
         "non-ascii": object,
     }
 
-    df = df.astype(astypes)    
+    df = df.astype(astypes)
     if compat.PANDAS_100:
         df["boolean"] = pd.Series([True, False, pd.NA], dtype="boolean")
         df["string"] = pd.Series(["foo", "bar", pd.NA], dtype="string")

--- a/pantab/tests/conftest.py
+++ b/pantab/tests/conftest.py
@@ -98,29 +98,30 @@ def df():
         ],
     )
 
-    astypes = {
-        "int16": np.int16,
-        "Int16": "Int16",
-        "int32": np.int32,
-        "Int32": "Int32",
-        "int64": np.int64,
-        "Int32": "Int32",
-        "float32": np.float32,
-        "float64": np.float64,
-        "bool": np.bool,
-        "datetime64": "datetime64[ns]",
-        "datetime64_utc": "datetime64[ns, UTC]",
-        "timedelta64": "timedelta64[ns]",
-        "object": object,
-        "int16_limits": np.int16,
-        "int32_limits": np.int32,
-        "int64_limits": np.int64,
-        "float32_limits": np.float64,
-        "float64_limits": np.float64,
-        "non-ascii": object,
-    }
+    df = df.astype(
+        {
+            "int16": np.int16,
+            "Int16": "Int16",
+            "int32": np.int32,
+            "Int32": "Int32",
+            "int64": np.int64,
+            "Int32": "Int32",
+            "float32": np.float32,
+            "float64": np.float64,
+            "bool": np.bool,
+            "datetime64": "datetime64[ns]",
+            "datetime64_utc": "datetime64[ns, UTC]",
+            "timedelta64": "timedelta64[ns]",
+            "object": "object",
+            "int16_limits": np.int16,
+            "int32_limits": np.int32,
+            "int64_limits": np.int64,
+            "float32_limits": np.float64,
+            "float64_limits": np.float64,
+            "non-ascii": "object",
+        }
+    )
 
-    df = df.astype(astypes)
     if compat.PANDAS_100:
         df["boolean"] = pd.Series([True, False, pd.NA], dtype="boolean")
         df["string"] = pd.Series(["foo", "bar", pd.NA], dtype="string")

--- a/pantab/tests/conftest.py
+++ b/pantab/tests/conftest.py
@@ -103,25 +103,25 @@ def df():
     )
 
     astypes = {
-            "int16": np.int16,
-            "Int16": "Int16",
-            "int32": np.int32,
-            "Int32": "Int32",
-            "int64": np.int64,
-            "Int32": "Int32",
-            "float32": np.float32,
-            "float64": np.float64,
-            "bool": np.bool,
-            "boolean": "boolean",
-            "datetime64": "datetime64[ns]",
-            "datetime64_utc": "datetime64[ns, UTC]",
-            "timedelta64": "timedelta64[ns]",
-            "int16_limits": np.int16,
-            "int32_limits": np.int32,
-            "int64_limits": np.int64,
-            "float32_limits": np.float64,
-            "float64_limits": np.float64,
-        }
+        "int16": np.int16,
+        "Int16": "Int16",
+        "int32": np.int32,
+        "Int32": "Int32",
+        "int64": np.int64,
+        "Int32": "Int32",
+        "float32": np.float32,
+        "float64": np.float64,
+        "bool": np.bool,
+        "boolean": "boolean",
+        "datetime64": "datetime64[ns]",
+        "datetime64_utc": "datetime64[ns, UTC]",
+        "timedelta64": "timedelta64[ns]",
+        "int16_limits": np.int16,
+        "int32_limits": np.int32,
+        "int64_limits": np.int64,
+        "float32_limits": np.float64,
+        "float64_limits": np.float64,
+    }
 
     if compat.PANDAS_100:
         astypes["string"] = "string"

--- a/pantab/tests/test_roundtrip.py
+++ b/pantab/tests/test_roundtrip.py
@@ -1,13 +1,10 @@
-from distutils.version import LooseVersion
-
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import tableauhyperapi as tab_api
 
 import pantab
-
-PANDAS_100 = LooseVersion(pd.__version__) >= LooseVersion("1.0.0")
+import pantab._compat as compat
 
 
 def test_basic(df, tmp_hyper, table_name, table_mode):
@@ -36,7 +33,7 @@ def test_missing_data(tmp_hyper, table_name, table_mode):
 
     result = pantab.frame_from_hyper(tmp_hyper, table=table_name)    
     expected = pd.DataFrame([[np.nan, np.nan, np.nan], [1, np.nan, "c"]], columns=list("abc"))
-    if PANDAS_100:
+    if compat.PANDAS_100:
         expected["b"] = expected["b"].astype("string")
         expected["c"] = expected["c"].astype("string")
 

--- a/pantab/tests/test_roundtrip.py
+++ b/pantab/tests/test_roundtrip.py
@@ -1,9 +1,13 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import tableauhyperapi as tab_api
 
 import pantab
+
+PANDAS_100 = LooseVersion(pd.__version__) >= LooseVersion("1.0.0")
 
 
 def test_basic(df, tmp_hyper, table_name, table_mode):
@@ -30,10 +34,12 @@ def test_missing_data(tmp_hyper, table_name, table_mode):
     pantab.frame_to_hyper(df, tmp_hyper, table=table_name, table_mode=table_mode)
     pantab.frame_to_hyper(df, tmp_hyper, table=table_name, table_mode=table_mode)
 
-    result = pantab.frame_from_hyper(tmp_hyper, table=table_name)
-    expected = pd.DataFrame(
-        [[np.nan, np.nan, np.nan], [1, np.nan, "c"]], columns=list("abc")
-    )
+    result = pantab.frame_from_hyper(tmp_hyper, table=table_name)    
+    expected = pd.DataFrame([[np.nan, np.nan, np.nan], [1, np.nan, "c"]], columns=list("abc"))
+    if PANDAS_100:
+        expected["b"] = expected["b"].astype("string")
+        expected["c"] = expected["c"].astype("string")
+
     if table_mode == "a":
         expected = pd.concat([expected, expected]).reset_index(drop=True)
 

--- a/pantab/tests/test_roundtrip.py
+++ b/pantab/tests/test_roundtrip.py
@@ -31,8 +31,10 @@ def test_missing_data(tmp_hyper, table_name, table_mode):
     pantab.frame_to_hyper(df, tmp_hyper, table=table_name, table_mode=table_mode)
     pantab.frame_to_hyper(df, tmp_hyper, table=table_name, table_mode=table_mode)
 
-    result = pantab.frame_from_hyper(tmp_hyper, table=table_name)    
-    expected = pd.DataFrame([[np.nan, np.nan, np.nan], [1, np.nan, "c"]], columns=list("abc"))
+    result = pantab.frame_from_hyper(tmp_hyper, table=table_name)
+    expected = pd.DataFrame(
+        [[np.nan, np.nan, np.nan], [1, np.nan, "c"]], columns=list("abc")
+    )
     if compat.PANDAS_100:
         expected["b"] = expected["b"].astype("string")
         expected["c"] = expected["c"].astype("string")

--- a/pantab/tests/test_writer.py
+++ b/pantab/tests/test_writer.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import re
 
 import numpy as np
@@ -7,6 +8,7 @@ import tableauhyperapi as tab_api
 
 import pantab
 
+PANDAS_100 = LooseVersion(pd.__version__) >= LooseVersion("1.0.0")
 
 def test_bad_table_mode_raises(df, tmp_hyper):
     msg = "'table_mode' must be either 'w' or 'a'"
@@ -20,7 +22,11 @@ def test_bad_table_mode_raises(df, tmp_hyper):
 def test_append_mode_raises_column_mismatch(df, tmp_hyper, table_name):
     pantab.frame_to_hyper(df, tmp_hyper, table=table_name)
 
-    df = df.drop("object", axis=1)
+    if PANDAS_100:
+        df = df.drop("string", axis=1)
+    else:
+        df = df.drop("object", axis=1)
+
     msg = "^Mismatched column definitions:"
     with pytest.raises(TypeError, match=msg):
         pantab.frame_to_hyper(df, tmp_hyper, table=table_name, table_mode="a")

--- a/pantab/tests/test_writer.py
+++ b/pantab/tests/test_writer.py
@@ -7,8 +7,8 @@ import pytest
 import tableauhyperapi as tab_api
 
 import pantab
+import pantab._compat as compat
 
-PANDAS_100 = LooseVersion(pd.__version__) >= LooseVersion("1.0.0")
 
 def test_bad_table_mode_raises(df, tmp_hyper):
     msg = "'table_mode' must be either 'w' or 'a'"
@@ -22,7 +22,7 @@ def test_bad_table_mode_raises(df, tmp_hyper):
 def test_append_mode_raises_column_mismatch(df, tmp_hyper, table_name):
     pantab.frame_to_hyper(df, tmp_hyper, table=table_name)
 
-    if PANDAS_100:
+    if compat.PANDAS_100:
         df = df.drop("string", axis=1)
     else:
         df = df.drop("object", axis=1)

--- a/pantab/tests/test_writer.py
+++ b/pantab/tests/test_writer.py
@@ -1,4 +1,3 @@
-from distutils.version import LooseVersion
 import re
 
 import numpy as np

--- a/pantab/tests/test_writer.py
+++ b/pantab/tests/test_writer.py
@@ -6,7 +6,6 @@ import pytest
 import tableauhyperapi as tab_api
 
 import pantab
-import pantab._compat as compat
 
 
 def test_bad_table_mode_raises(df, tmp_hyper):
@@ -21,11 +20,7 @@ def test_bad_table_mode_raises(df, tmp_hyper):
 def test_append_mode_raises_column_mismatch(df, tmp_hyper, table_name):
     pantab.frame_to_hyper(df, tmp_hyper, table=table_name)
 
-    if compat.PANDAS_100:
-        df = df.drop("string", axis=1)
-    else:
-        df = df.drop("object", axis=1)
-
+    df = df.drop("object", axis=1)
     msg = "^Mismatched column definitions:"
     with pytest.raises(TypeError, match=msg):
         pantab.frame_to_hyper(df, tmp_hyper, table=table_name, table_mode="a")


### PR DESCRIPTION
closes #20

Need to update docs and get CI to pull in RC, but this passes locally.

Will by default read types into "string" going forward instead of "object" when coming from Tableau, as a more natural data type
