### PR TITLE
Fix error handling

### DIFF
--- a/pantab/newsfragments/77.bugfix
+++ b/pantab/newsfragments/77.bugfix
@@ -1,0 +1,1 @@
+Fixed issue where Python would crash instead of throwing an error when reading invalid records from a Hyper file


### PR DESCRIPTION
We were accidentally double-freeing the result tuples in case of an
error. Python lists and tuples already take care of `DECREF`ing their
members on their own. No need for us to do this

Furthermore, the `j2 < j - 2` was underflowing for `j == 0` in
> for (size_t j2 = 0; j2 < j - 2; j2++) {
which lead to a segfault

This is the first of a series of commits to address the segfault which @ShashankBharadwaj25 reported in #77 