### PR TITLE
Add support for an externally provided HyperProcess

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,35 +1,39 @@
 API Reference
 =============
 
-.. py:function:: frame_to_hyper(df: pd.DataFrame, database: Union[str, pathlib.Path], *, table: Union[str, tableauhyperapi.Name, tableauhyperapi.TableName]) -> None:
+.. py:function:: frame_to_hyper(df: pd.DataFrame, database: Union[str, pathlib.Path], *, table: Union[str, tableauhyperapi.Name, tableauhyperapi.TableName], hyper_process: Optional[HyperProcess]) -> None:
 
    Convert a DataFrame to a .hyper extract.
 
    :param df: Data to be written out.
    :param database: Name / location of the Hyper file to write to.
    :param table: Table to write to. Must be supplied as a keyword argument.
+   :param hyper_process: A `HyperProcess` in case you want to spawn it by yourself. Optional. Must be supplied as a keyword argument.
 
 
-.. py:function:: frame_from_hyper(database: Union[str, pathlib.Path], *, table: Union[str, tableauhyperapi.Name, tableauhyperapi.TableName]) -> pd.DataFrame:
+.. py:function:: frame_from_hyper(database: Union[str, pathlib.Path], *, table: Union[str, tableauhyperapi.Name, tableauhyperapi.TableName], hyper_process: Optional[HyperProcess]) -> pd.DataFrame:
 
    Extracts a DataFrame from a .hyper extract.
 
    :param database: Name / location of the Hyper file to be read.
    :param table: Table to read. Must be supplied as a keyword argument.
+   :param hyper_process: A `HyperProcess` in case you want to spawn it by yourself. Optional. Must be supplied as a keyword argument.
    :rtype: pd.DataFrame
 
 
-.. py:function:: frames_to_hyper(dict_of_frames: Dict[Union[str, tableauhyperapi.Name, tableauhyperapi.TableName], pd.DataFrame], database: Union[str, pathlib.Path]) -> None:
+.. py:function:: frames_to_hyper(dict_of_frames: Dict[Union[str, tableauhyperapi.Name, tableauhyperapi.TableName], pd.DataFrame], database: Union[str, pathlib.Path], *, hyper_process: Optional[HyperProcess]) -> None:
 
    Writes multiple DataFrames to a .hyper extract.
 
    :param dict_of_frames: A dictionary whose keys are valid table identifiers and values are dataframes
    :param database: Name / location of the Hyper file to write to.
+   :param hyper_process: A `HyperProcess` in case you want to spawn it by yourself. Optional. Must be supplied as a keyword argument.
 
 
-.. py:function:: frames_from_hyper(database: Union[str, pathlib.Path]) -> Dict[tableauhyperapi.TableName, pd.DataFrame]:
+.. py:function:: frames_from_hyper(database: Union[str, pathlib.Path], *, hyper_process: Optional[HyperProcess]) -> Dict[tableauhyperapi.TableName, pd.DataFrame]:
 
    Extracts tables from a .hyper extract.
 
    :param database: Name / location of the Hyper file to read from.
+   :param hyper_process: A `HyperProcess` in case you want to spawn it by yourself. Optional. Must be supplied as a keyword argument.
    :rtype: Dict[tableauhyperapi.TableName, pd.DataFrame]

--- a/pantab/_hyper_util.py
+++ b/pantab/_hyper_util.py
@@ -1,0 +1,28 @@
+from contextlib import contextmanager
+from typing import Optional
+
+import tableauhyperapi as tab_api
+
+
+# As soon as we drop support for Python 3.6: Use `contextlib.nullcontext` instead
+@contextmanager
+def nullcontext(enter_result=None):
+    yield enter_result
+
+
+def ensure_hyper_process(hyper_process: Optional[tab_api.HyperProcess]):
+    """
+    Spawns an adhoc HyperProcess if needed, i.e. if no existing HyperProcess is provided
+
+    Usage:
+    ```
+    with ensure_hyper_process(<HyperProcess or None>) as h:
+        h.execute_query(...)
+    ```
+    """
+    if hyper_process is None:
+        return tab_api.HyperProcess(tab_api.Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU)
+    else:
+        # Wrap the HyperProcess into a nullcontext such that the `with` doesn't close
+        # the HyperProcess
+        return nullcontext(hyper_process)

--- a/pantab/_reader.py
+++ b/pantab/_reader.py
@@ -1,7 +1,7 @@
 import pathlib
 import shutil
 import tempfile
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -9,6 +9,7 @@ import tableauhyperapi as tab_api
 
 import libreader  # type: ignore
 import pantab._types as pantab_types
+from pantab._hyper_util import ensure_hyper_process
 
 TableType = Union[str, tab_api.Name, tab_api.TableName]
 
@@ -50,11 +51,15 @@ def _read_table(*, connection: tab_api.Connection, table: TableType) -> pd.DataF
 
 
 def frame_from_hyper(
-    database: Union[str, pathlib.Path], *, table: TableType
+    database: Union[str, pathlib.Path],
+    *,
+    table: TableType,
+    hyper_process: Optional[tab_api.HyperProcess] = None,
 ) -> pd.DataFrame:
     """See api.rst for documentation"""
-    with tempfile.TemporaryDirectory() as tmp_dir, tab_api.HyperProcess(
-        tab_api.Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU
+
+    with tempfile.TemporaryDirectory() as tmp_dir, ensure_hyper_process(
+        hyper_process
     ) as hpe:
         tmp_db = shutil.copy(database, tmp_dir)
         with tab_api.Connection(hpe.endpoint, tmp_db) as connection:
@@ -62,12 +67,14 @@ def frame_from_hyper(
 
 
 def frames_from_hyper(
-    database: Union[str, pathlib.Path]
+    database: Union[str, pathlib.Path],
+    *,
+    hyper_process: Optional[tab_api.HyperProcess] = None,
 ) -> Dict[tab_api.TableName, pd.DataFrame]:
     """See api.rst for documentation."""
     result: Dict[TableType, pd.DataFrame] = {}
-    with tempfile.TemporaryDirectory() as tmp_dir, tab_api.HyperProcess(
-        tab_api.Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU
+    with tempfile.TemporaryDirectory() as tmp_dir, ensure_hyper_process(
+        hyper_process
     ) as hpe:
         tmp_db = shutil.copy(database, tmp_dir)
         with tab_api.Connection(hpe.endpoint, tmp_db) as connection:

--- a/pantab/_writer.py
+++ b/pantab/_writer.py
@@ -11,6 +11,7 @@ import tableauhyperapi as tab_api
 
 import libwriter  # type: ignore
 import pantab._types as pantab_types
+from pantab._hyper_util import ensure_hyper_process
 
 
 def _pandas_to_tableau_type(typ: str) -> pantab_types._ColumnType:
@@ -164,11 +165,10 @@ def frame_to_hyper(
     *,
     table: pantab_types.TableType,
     table_mode: str = "w",
+    hyper_process: Optional[tab_api.HyperProcess] = None,
 ) -> None:
     """See api.rst for documentation"""
-    with tab_api.HyperProcess(
-        tab_api.Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU
-    ) as hpe:
+    with ensure_hyper_process(hyper_process) as hpe:
         tmp_db = pathlib.Path(tempfile.gettempdir()) / f"{uuid.uuid4()}.hyper"
 
         if table_mode == "a" and pathlib.Path(database).exists():
@@ -188,13 +188,13 @@ def frames_to_hyper(
     dict_of_frames: Dict[pantab_types.TableType, pd.DataFrame],
     database: Union[str, pathlib.Path],
     table_mode: str = "w",
+    *,
+    hyper_process: Optional[tab_api.HyperProcess] = None,
 ) -> None:
     """See api.rst for documentation."""
     _validate_table_mode(table_mode)
 
-    with tab_api.HyperProcess(
-        tab_api.Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU
-    ) as hpe:
+    with ensure_hyper_process(hyper_process) as hpe:
         tmp_db = pathlib.Path(tempfile.gettempdir()) / f"{uuid.uuid4()}.hyper"
 
         if table_mode == "a" and pathlib.Path(database).exists():


### PR DESCRIPTION
So far, pantab always internally created an adhoc `HyperProcess`. This
commit allows users to instead spawn their own `HyperProcess` and pass
it to pantab's functions through a `hyper` keyword argument.

By providing their own `HyperProcess`, users
* have full control over the start-up flags of `HyperProcess` and can,
  e.g., disable the creation of the `hyperd.log` log file.
* reuse the same `HyperProcess` across multiple function calls and
  thereby save a few milliseconds per function invocation.
 
 closes #51, closes #39