### PR TITLE
Improve reader: Simplify C library and add `frame_from_hyper_query` function

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -37,3 +37,13 @@ API Reference
    :param database: Name / location of the Hyper file to read from.
    :param hyper_process: A `HyperProcess` in case you want to spawn it by yourself. Optional. Must be supplied as a keyword argument.
    :rtype: Dict[tableauhyperapi.TableName, pd.DataFrame]
+
+
+.. py:function:: frame_from_hyper_query(database: Union[str, pathlib.Path], query: str, *, hyper_process: Optional[HyperProcess]) -> pd.DataFrame:
+
+   Executes a SQL query and returns the result as a pandas dataframe
+
+   :param database: Name / location of the Hyper file to be read.
+   :param query: SQL query to execute
+   :param hyper_process: A `HyperProcess` in case you want to spawn it by yourself. Optional. Must be supplied as a keyword argument.
+   :rtype: Dict[tableauhyperapi.TableName, pd.DataFrame]

--- a/doc/source/caveats.rst
+++ b/doc/source/caveats.rst
@@ -42,12 +42,14 @@ pantab maps the following dtypes from pandas to the equivalent column type in Ta
 
 Any dtype not explicitly listed in the above table will raise a ValueError if trying to write out data.
 
+When reading data through ``frame_from_hyper_query``, pantab will always assume that all result columns are nullable.
+
 .. versionadded:: 1.0.0
    If using pandas 1.0 and above, text data will be read back into a ``string`` dtype rather than an ``object`` dtype.
 
 .. note::
 
-   Most objects can maintain their type when "round-tripping" to/from Hyper extracts, with the exception of the float32 object as only DOUBLE is available for floating point storage in Hyper. After pandas 1.0 / pantab 1.0, object dtypes written will be read back in as string.
+   Most objects can maintain their type when "round-tripping" to/from Hyper extracts, with the exception of the float32 object as only DOUBLE is available for floating point storage in Hyper. After pandas 1.0 / pantab 1.0, object dtypes written will be read back in as string. Also, reading data back through ``frame_from_hyper_query`` will likely read back different dtypes, as ``frame_from_hyper_query`` assumes all columns to be nullable.
 
 Index / Column Handling
 -----------------------

--- a/pantab/__init__.py
+++ b/pantab/__init__.py
@@ -1,13 +1,14 @@
 __version__ = "1.1.1"
 
 
-from ._reader import frame_from_hyper, frames_from_hyper
+from ._reader import frame_from_hyper, frame_from_hyper_query, frames_from_hyper
 from ._tester import test
 from ._writer import frame_to_hyper, frames_to_hyper
 
 __all__ = [
     "__version__",
     "frame_from_hyper",
+    "frame_from_hyper_query",
     "frames_from_hyper",
     "frame_to_hyper",
     "frames_to_hyper",

--- a/pantab/_reader.py
+++ b/pantab/_reader.py
@@ -14,6 +14,43 @@ from pantab._hyper_util import ensure_hyper_process
 TableType = Union[str, tab_api.Name, tab_api.TableName]
 
 
+def _read_query_result(
+    result: tab_api.Result,
+    dtypes: Optional[Dict[str, str]],
+) -> pd.DataFrame:
+    if dtypes is None:
+        dtypes = {}
+        # Construct data types from result
+        for column in result.schema.columns:
+            # `result.schema` does not provide nullability information.
+            # Lwt's err on the safe side and always assume they are nullable
+            nullability = tab_api.Nullability.NULLABLE
+            column_type = pantab_types._ColumnType(column.type, nullability)
+            try:
+                dtypes[column.name.unescaped] = pantab_types._pandas_types[column_type]
+            except KeyError as e:
+                raise TypeError(
+                    f"Column {column.name} has unsupported datatype {column.type} "
+                    f"with nullability {column.nullability}"
+                ) from e
+
+    # Call native library to read tuples from result set
+    dtype_strs = tuple(dtypes.values())
+    df = pd.DataFrame(libreader.read_hyper_query(result._Result__cdata, dtype_strs))
+
+    df.columns = dtypes.keys()
+
+    # TODO: remove this hackery...
+    for k, v in dtypes.items():
+        if v == "date":
+            dtypes[k] = "datetime64[ns]"
+
+    df = df.astype(dtypes)
+    df = df.fillna(value=np.nan)  # Replace any appearances of None
+
+    return df
+
+
 def _read_table(*, connection: tab_api.Connection, table: TableType) -> pd.DataFrame:
     if isinstance(table, str):
         table = tab_api.TableName(table)
@@ -33,22 +70,8 @@ def _read_table(*, connection: tab_api.Connection, table: TableType) -> pd.DataF
             ) from e
 
     query = f"SELECT * from {table}"
-    dtype_strs = tuple(dtypes.values())
-
     with connection.execute_query(query) as result:
-        df = pd.DataFrame(libreader.read_hyper_query(result._Result__cdata, dtype_strs))
-
-    df.columns = dtypes.keys()
-
-    # TODO: remove this hackery...
-    for k, v in dtypes.items():
-        if v == "date":
-            dtypes[k] = "datetime64[ns]"
-
-    df = df.astype(dtypes)
-    df = df.fillna(value=np.nan)  # Replace any appearances of None
-
-    return df
+        return _read_query_result(result, dtypes)
 
 
 def frame_from_hyper(
@@ -84,3 +107,17 @@ def frames_from_hyper(
                     result[table] = _read_table(connection=connection, table=table)
 
     return result
+
+
+def frame_from_hyper_query(
+    database: Union[str, pathlib.Path],
+    query: str,
+    *,
+    hyper: Optional[tab_api.HyperProcess] = None,
+) -> pd.DataFrame:
+    """See api.rst for documentation."""
+    with tempfile.TemporaryDirectory() as tmp_dir, ensure_hyper_process(hyper) as hpe:
+        tmp_db = shutil.copy(database, tmp_dir)
+        with tab_api.Connection(hpe.endpoint, tmp_db) as connection:
+            with connection.execute_query(query) as result:
+                return _read_query_result(result, None)

--- a/pantab/_reader.py
+++ b/pantab/_reader.py
@@ -35,7 +35,8 @@ def _read_table(*, connection: tab_api.Connection, table: TableType) -> pd.DataF
     query = f"SELECT * from {table}"
     dtype_strs = tuple(dtypes.values())
 
-    df = pd.DataFrame(libreader.read_hyper_query(connection._cdata, query, dtype_strs))
+    with connection.execute_query(query) as result:
+        df = pd.DataFrame(libreader.read_hyper_query(result._Result__cdata, dtype_strs))
 
     df.columns = dtypes.keys()
 

--- a/pantab/tableauhyperapi.h
+++ b/pantab/tableauhyperapi.h
@@ -61,9 +61,6 @@ hyper_error_t *hyper_inserter_buffer_add_raw(hyper_inserter_buffer_t *buffer,
 typedef struct hyper_connection_t hyper_connection_t;
 typedef struct hyper_rowset_t hyper_rowset_t;
 typedef struct hyper_rowset_chunk_t hyper_rowset_chunk_t;
-void hyper_close_rowset(hyper_rowset_t *rowset);
-hyper_error_t *hyper_execute_query(hyper_connection_t *connection,
-                                   const char *query, hyper_rowset_t **rowset);
 hyper_error_t *hyper_rowset_get_next_chunk(hyper_rowset_t *rowset,
                                            hyper_rowset_chunk_t **rowset_chunk);
 void hyper_destroy_rowset_chunk(const hyper_rowset_chunk_t *rowset_chunk);


### PR DESCRIPTION
This pull request contains two commits:
* the 1st commit simplified the C-library used by the reader
* the 2nd commit introduces a new `frame_from_hyper_query` function which allows to retrieve the results of arbitrary SQL queries as Pandas DataFrames

See the individual commit messages for more details.

Note that this branch also includes the commits from #117 to avoid unnecessary merge conflicts. Please comment on those commits in the other pull request