### PR TITLE
Stop reading 0001-01-01 as NULL Timestamp

### DIFF
--- a/pantab/src/_readermodule.c
+++ b/pantab/src/_readermodule.c
@@ -50,14 +50,6 @@ static PyObject *read_value(const uint8_t *value, DTYPE dtype,
         hyper_date_components_t date = hyper_decode_date(encoded_date);
         hyper_time_components_t time = hyper_decode_time(encoded_time);
 
-        // Special case NULL value as it isn't contained in null_flags
-        // Note that the sentinel to compare to varies by platform, so
-        // have to fully parse and compare components for now
-        if ((date.year == 1) && (date.month == 1) && (date.day == 1) &&
-            (time.hour == 0) && (time.minute == 0) && (time.microsecond == 0)) {
-            Py_RETURN_NONE;
-        }
-
         return PyDateTime_FromDateAndTime(date.year, date.month, date.day,
                                           time.hour, time.minute, time.second,
                                           time.microsecond);


### PR DESCRIPTION
Over two years ago, pantab had a bug due to which `pandas.NaT` was
written to Hyper files as "0001-01-01".
Consequently, the reader was also written to interpret "0001-01-01"
as NULL. This was never quite correct, but was kept as is to not break
backwards compatibility.

Now, two years later, it's time to remove that hack.

closes #64
