### PR TITLE
Optimization: Pass datetime64 as int64 directly as epoch offset instead of using datetime object

### DIFF
--- a/pantab/_writer.py
+++ b/pantab/_writer.py
@@ -109,7 +109,7 @@ def _maybe_convert_datetime_or_timedelta(
             if content.dtype == "timedelta64[ns]":
                 df.iloc[:, index] = content.apply(_timedelta_to_interval)
             if content.dtype == "datetime64[ns]":
-                df.iloc[:, index] = content.astype(int) // 1000 + (
+                df.iloc[:, index] = pd.to_numeric(content) // 1000 + (
                     2_440_588  # of days between Tableau and Unix epochs
                     * 86400  # seconds in a day
                     * 1_000_000  # microseconds in a second

--- a/pantab/_writer.py
+++ b/pantab/_writer.py
@@ -81,13 +81,15 @@ def _assert_columns_equal(
     raise TypeError(f"Mismatched column definitions: {c1_str} != {c2_str}")
 
 
-def _maybe_convert_datetime_or_timedelta(df: pd.DataFrame) -> Tuple[pd.DataFrame, Tuple[str, ...]]:
+def _maybe_convert_datetime_or_timedelta(
+    df: pd.DataFrame,
+) -> Tuple[pd.DataFrame, Tuple[str, ...]]:
     """
     Hyper uses a different storage format than pandas / Python for timedeltas.
 
     Ultimately this should be pushed to the C extension, but doesn't look to fully work
     at the moment anyway so keep in Python until complete.
-    
+
     For datetimes, Hyper uses "microseconds since midnight 24-11-4714 BC".
     # https://community.tableau.com/s/question/0D54T00000C5Qd1SAF/tableau-hyper-api-datetime-int64-format
 
@@ -108,10 +110,9 @@ def _maybe_convert_datetime_or_timedelta(df: pd.DataFrame) -> Tuple[pd.DataFrame
                 df.iloc[:, index] = content.apply(_timedelta_to_interval)
             if content.dtype == "datetime64[ns]":
                 df.iloc[:, index] = content.astype(int) // 1000 + (
-                    # 2440588 is the # of days between 
-                    # 86400 seconds in a day
-                    # 1_000_000 microseconds in a second
-                    2_440_588 * 86400 * 1_000_000
+                    2_440_588  # of days between Tableau and Unix epochs
+                    * 86400  # seconds in a day
+                    * 1_000_000  # microseconds in a second
                 )
 
     return df, orig_dtypes

--- a/pantab/src/writer.c
+++ b/pantab/src/writer.c
@@ -45,27 +45,10 @@ static hyper_error_t *writeNonNullData(PyObject *data, DTYPE dtype,
     }
     case DATETIME64_NS:
     case DATETIME64_NS_UTC: {
-        hyper_date_components_t date_components = {
-            .year = PyDateTime_GET_YEAR(data),
-            .month = PyDateTime_GET_MONTH(data),
-            .day = PyDateTime_GET_DAY(data)};
-
-        hyper_time_components_t time_components = {
-            .hour = PyDateTime_DATE_GET_HOUR(data),
-            .minute = PyDateTime_DATE_GET_MINUTE(data),
-            .second = PyDateTime_DATE_GET_SECOND(data),
-            .microsecond = PyDateTime_DATE_GET_MICROSECOND(data)};
-
-        hyper_date_t date = hyper_encode_date(date_components);
-        hyper_time_t time = hyper_encode_time(time_components);
-
-        // TODO: Tableau uses typedefs for unsigned 32 / 64 integers for
-        // date and time respectively, but stores as int64; here we cast
-        // explicitly but should probably bounds check for overflow as well
-        int64_t val = (int64_t)time + (int64_t)date * MICROSECONDS_PER_DAY;
-
+        int64_t val = (int64_t)PyLong_AsLongLong(data);
         result = hyper_inserter_buffer_add_int64(insertBuffer, val);
         break;
+        // hyper_
     }
     case TIMEDELTA64_NS: {
         // TODO: Add error message for failed attribute access

--- a/pantab/src/writer.c
+++ b/pantab/src/writer.c
@@ -48,7 +48,6 @@ static hyper_error_t *writeNonNullData(PyObject *data, DTYPE dtype,
         int64_t val = (int64_t)PyLong_AsLongLong(data);
         result = hyper_inserter_buffer_add_int64(insertBuffer, val);
         break;
-        // hyper_
     }
     case TIMEDELTA64_NS: {
         // TODO: Add error message for failed attribute access


### PR DESCRIPTION
closes #41

This PR translates the datetime64 Timestamps into the native microseconds after the Tableau epoch, which is significantly faster than calculating the year/month/day/hour/min/second from the Python datetime object.  (5MM+ datetime64 insertions in 1.55 seconds instead of 4.71 seconds).  

### Test Code:
```
import pantab
import pandas as pd

df = pd.DataFrame(dict(dt=pd.date_range(pd.Timestamp.min, pd.Timestamp.max, freq="H")))
print('BEFORE: ')
print(df.shape)
print(df.head())
print(df.tail())
pantab.frame_to_hyper(df, "/tmp/test.hyper", table="Extract.Extract")

print(80*'-')

print('AFTER: ')
df2 = pantab.frame_from_hyper("/tmp/test.hyper", table="Extract.Extract").sort_values("dt").reset_index(drop=True)
print(df.shape)
print(df2.head())
print(df2.tail())

pd.testing.assert_frame_equal(df, df2, check_exact=True)
```

### Benchmark code
```
import pantab
import pandas as pd
from time import perf_counter

print("Pantab Source:", pantab.__file__)
df = pd.DataFrame(dict(dt=pd.date_range(pd.Timestamp.min, pd.Timestamp.max, freq="H")))
print("BEFORE: ")
print(df.shape)
print(df.head())
print(df.tail())
time_start = perf_counter()
pantab.frame_to_hyper(df, "/tmp/test.hyper", table="Extract.Extract")
print("Execution Time:", perf_counter() - time_start)
```


