### PR TITLE
Don't link against HyperAPI

### DIFF
--- a/pantab/__init__.py
+++ b/pantab/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "1.1.1"
 
-
+import libpantab  # type: ignore
 from ._reader import frame_from_hyper, frame_from_hyper_query, frames_from_hyper
 from ._tester import test
 from ._writer import frame_to_hyper, frames_to_hyper
@@ -14,3 +14,100 @@ __all__ = [
     "frames_to_hyper",
     "test",
 ]
+
+# We link against HyperAPI in a fun way: In Python, we extract the function
+# pointers directly from the Python HyperAPI. We pass those function pointers
+# over to the C module which will then use those pointers to directly interact
+# with HyperAPI. Furthermore, we check the function signatures to guard
+# against API-breaking changes in HyperAPI.
+#
+# Directly using HyperAPI's C functions always was and still is discouraged and
+# unsupported by Tableu. In particular, Tableau will not be able to provide
+# official support for this hack.
+#
+# Because this is highly brittle, we try to make the error message as
+# actionable as possible and guide users in the right direction.
+
+api_incompatibility_msg = """
+pantab is incompatible with the version of Tableau Hyper API installed on your
+system. Please upgrade both `tableauhyperapi` and `pantab` to the latest version.
+If doing so does not fix this issue, please file an issue at
+https://github.com/innobi/pantab/issues mentioning the exact pantab and HyperAPI
+versions which triggered this error.
+"""
+
+try:
+    from tableauhyperapi.impl.dll import lib, ffi
+except ImportError as e:
+    raise NotImplementedError(api_incompatibility_msg) from e
+
+
+def _check_compatibility(check, message):
+    if not check:
+        raise NotImplementedError(message + "\n" + api_incompatibility_msg)
+
+
+def _get_hapi_function(name, sig):
+    _check_compatibility(hasattr(lib, name), f"function '{name}' missing")
+    f = getattr(lib, name)
+    func_type = ffi.typeof(f)
+    _check_compatibility(
+        func_type.kind == "function",
+        f"expected '{name}' to be a function, got {func_type.kind}",
+    )
+    _check_compatibility(
+        func_type.cname == sig,
+        f"expected '{name}' to have the signature '{sig}', got '{func_type.cname}'",
+    )
+    return f
+
+
+libpantab.load_hapi_functions(
+    _get_hapi_function("hyper_decode_date", "hyper_date_components_t(*)(uint32_t)"),
+    _get_hapi_function("hyper_encode_date", "uint32_t(*)(hyper_date_components_t)"),
+    _get_hapi_function("hyper_decode_time", "hyper_time_components_t(*)(uint64_t)"),
+    _get_hapi_function("hyper_encode_time", "uint64_t(*)(hyper_time_components_t)"),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_null",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *)",
+    ),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_bool",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *, _Bool)",
+    ),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_int16",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *, int16_t)",
+    ),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_int32",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *, int32_t)",
+    ),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_int64",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *, int64_t)",
+    ),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_double",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *, double)",
+    ),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_binary",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *, uint8_t *, size_t)",
+    ),
+    _get_hapi_function(
+        "hyper_inserter_buffer_add_raw",
+        "struct hyper_error_t *(*)(struct hyper_inserter_buffer_t *, uint8_t *, size_t)",
+    ),
+    _get_hapi_function(
+        "hyper_rowset_get_next_chunk",
+        "struct hyper_error_t *(*)(struct hyper_rowset_t *, struct hyper_rowset_chunk_t * *)",
+    ),
+    _get_hapi_function(
+        "hyper_destroy_rowset_chunk", "void(*)(struct hyper_rowset_chunk_t *)"
+    ),
+    _get_hapi_function(
+        "hyper_rowset_chunk_field_values",
+        "struct hyper_error_t *(*)(struct hyper_rowset_chunk_t *, size_t *, size_t *, uint8_t * * *, size_t * *, int8_t * *)",
+    ),
+)

--- a/pantab/src/tableauhyperapi.h
+++ b/pantab/src/tableauhyperapi.h
@@ -34,40 +34,32 @@ typedef struct {
     int8_t second;
     int32_t microsecond;
 } hyper_time_components_t;
-hyper_date_components_t hyper_decode_date(hyper_date_t date);
-hyper_date_t hyper_encode_date(hyper_date_components_t components);
-hyper_time_components_t hyper_decode_time(hyper_time_t time);
-hyper_time_t hyper_encode_time(hyper_time_components_t components);
 
 typedef struct hyper_error_t hyper_error_t;
 typedef struct hyper_inserter_buffer_t hyper_inserter_buffer_t;
-hyper_error_t *hyper_inserter_buffer_add_null(hyper_inserter_buffer_t *buffer);
-hyper_error_t *hyper_inserter_buffer_add_bool(hyper_inserter_buffer_t *buffer,
-                                              bool value);
-hyper_error_t *hyper_inserter_buffer_add_int16(hyper_inserter_buffer_t *buffer,
-                                               int16_t value);
-hyper_error_t *hyper_inserter_buffer_add_int32(hyper_inserter_buffer_t *buffer,
-                                               int32_t value);
-hyper_error_t *hyper_inserter_buffer_add_int64(hyper_inserter_buffer_t *buffer,
-                                               int64_t value);
-hyper_error_t *hyper_inserter_buffer_add_double(hyper_inserter_buffer_t *buffer,
-                                                double value);
-hyper_error_t *hyper_inserter_buffer_add_binary(hyper_inserter_buffer_t *buffer,
-                                                const uint8_t *value,
-                                                size_t size);
-hyper_error_t *hyper_inserter_buffer_add_raw(hyper_inserter_buffer_t *buffer,
-                                             const uint8_t *value, size_t size);
-
-typedef struct hyper_connection_t hyper_connection_t;
 typedef struct hyper_rowset_t hyper_rowset_t;
 typedef struct hyper_rowset_chunk_t hyper_rowset_chunk_t;
-hyper_error_t *hyper_rowset_get_next_chunk(hyper_rowset_t *rowset,
-                                           hyper_rowset_chunk_t **rowset_chunk);
-void hyper_destroy_rowset_chunk(const hyper_rowset_chunk_t *rowset_chunk);
-hyper_error_t *hyper_rowset_chunk_field_values(
-    hyper_rowset_chunk_t *rowset_chunk, size_t *col_count, size_t *row_count,
-    const uint8_t *const *values[], const size_t *sizes[],
-    const int8_t *null_flags[]);
+
+#define HYPERAPI_FUNCTIONS(C) \
+    C(hyper_date_components_t, hyper_decode_date, (hyper_date_t date)) \
+    C(hyper_date_t, hyper_encode_date, (hyper_date_components_t components)) \
+    C(hyper_time_components_t, hyper_decode_time, (hyper_time_t time)) \
+    C(hyper_time_t, hyper_encode_time, (hyper_time_components_t components)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_null, (hyper_inserter_buffer_t *buffer)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_bool, (hyper_inserter_buffer_t *buffer, bool value)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_int16, (hyper_inserter_buffer_t *buffer, int16_t value)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_int32, (hyper_inserter_buffer_t *buffer, int32_t value)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_int64, (hyper_inserter_buffer_t *buffer, int64_t value)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_double, (hyper_inserter_buffer_t *buffer, double value)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_binary, (hyper_inserter_buffer_t *buffer, const uint8_t *value, size_t size)) \
+    C(hyper_error_t *, hyper_inserter_buffer_add_raw, (hyper_inserter_buffer_t *buffer, const uint8_t *value, size_t size)) \
+    C(hyper_error_t *, hyper_rowset_get_next_chunk, (hyper_rowset_t *rowset, hyper_rowset_chunk_t **rowset_chunk)) \
+    C(void,  hyper_destroy_rowset_chunk, (const hyper_rowset_chunk_t *rowset_chunk)) \
+    C(hyper_error_t *, hyper_rowset_chunk_field_values, (hyper_rowset_chunk_t *rowset_chunk, size_t *col_count, size_t *row_count, const uint8_t *const *values[], const size_t *sizes[], const int8_t *null_flags[]))
+
+#define C(RET, NAME, ARGS) extern RET(*NAME)ARGS;
+HYPERAPI_FUNCTIONS(C)
+#undef C
 
 // custom addition from the Python binding; mistmatch with C API
 typedef struct {

--- a/setup.py
+++ b/setup.py
@@ -4,41 +4,10 @@ from glob import glob
 
 from setuptools import Extension, find_packages, setup
 
-try:
-    from tableauhyperapi.impl.util import find_hyper_api_dll
-except ImportError:  # renamed in version 0.0.10309
-    from tableauhyperapi.impl.util import find_hyper_api_library as find_hyper_api_dll
-
-
 here = os.path.abspath(os.path.dirname(__file__))
-dll_path = find_hyper_api_dll()
 
 with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
-
-if sys.platform.startswith("win32"):
-    # Looks like the Tableau Python source doesn't have the needed lib file
-    # so extract from C++ distributions
-    import io
-    import zipfile
-    from urllib.request import urlopen
-
-    data = urlopen(
-        "http://downloads.tableau.com/tssoftware/tableauhyperapi-cxx-windows-x86_64"
-        "-release-hyperapi_release_6.0.0.10309.rf8b2e5f7.zip"
-    )
-    target = dll_path.parent / "tableauhyperapi.lib"
-    print(f"extract lib to {target}")
-    with zipfile.ZipFile(io.BytesIO(data.read())) as archive:
-        target.write_bytes(
-            archive.open(
-                "tableauhyperapi-cxx-windows-x86_64-release-hyperapi_release"
-                "_6.0.0.10309.rf8b2e5f7/lib/tableauhyperapi.lib"
-            ).read()
-        )
-
-
-extra_compile_args = ["-Wextra"]
 
 
 # MSVC compiler has different flags; assume that's what we are using on Windows
@@ -51,8 +20,6 @@ else:
 pantab_module = Extension(
     "libpantab",
     sources=list(glob("pantab/src/*.c")),
-    library_dirs=[str(dll_path.parent.resolve())],
-    libraries=[dll_path.stem.replace("lib", "")],
     depends=list(glob("pantab/src/*.h")),
     extra_compile_args=extra_compile_args,
 )


### PR DESCRIPTION
In the past, users reported crashes in pantab (#116, #99) a few times
already. Those crashes were due to ABI-breaking changes in HyperAPI and
the way pantab was using HyperAPI.

So far, pantab linked against the C-library `libtableauhyperapi.so` from
HyperAPI at build time of its `libpantab` C module. This meant, that at
runtime there we two copies of HyperAPI's C-library loaded:
1. The version used by the `tableauhyperapi` Python package
2. The version which pantab was linked against

The Python code then went on and passed a `hyper_connection_t*` created
by `tableauhyperapi`'s `libtableauhyperapi.so` into pantab's version of
`libtableauhyperapi.so`.

This worked fine, as long as both versions of `libtableauhyperapi.so`
have the same version. As soon as the versions mismatched, though,
passing pointer between those two versions of the same library is
dangerous: As soon as there is an ABI breaking change, pantab would
crash.

This commit fixes the issue by changing how pantab interacts with
HyperAPI: pantab no longer links against `libtableauhyperapi.so`.
Thereby, we no longer have two versions of the same library loaded at
runtime. Instead, pantab will also use the exact same functions as the
`tableauhyperapi` Python package.

To get access to those functions
* At initialization time, we extract the function pointers from
  `tableauhyperapi` and pass them to pantab's C extension.
* The C extension stores those pointers in global variables
* When calling a function from `libtableauhyperapi.so`, pantab's C module
  calls the HyperAPI functions using those stored funcction pointers

All in all, this means that pantab will no longer be broken by
ABI-breaking changes to HyperAPI. Only API-breaking changes would still
break pantab. This is a real risk because the `libtableauhyperapi.so`'s
C interface is an internal implementation detail of HyperAPI and not
part of the officially supported, stable API. Directly using HyperAPI's
C functions always was and still is discouraged and unsupported.

To guard against API-breaking changes we check that all functions have the
expected call signature at initalization time.