### PR TITLE
remove warning about incompatibility with tableauhyperapi>=0.0.14567

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,9 +10,6 @@ pantab
    changelog
    support
 
-.. important::
-
-   pantab is currently incompatible with tableauhyperapi>=0.0.14567. For details and status updates see `GitHub issue #145 <https://github.com/innobi/pantab/issues/145>`_
 
 What is it?
 -----------


### PR DESCRIPTION
this warning is now misleading giving the fact that support for tableauhyperapi>=0.0.14567 was added in https://github.com/innobi/pantab/commit/966ca46799fbbf6c1951bc18d7b732521fe108a9
