### PR TITLE
Link Slack channel from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ https://pantab.readthedocs.io/en/latest/index.html
 
 ## Community
 
-If you'd like to chat with the developer(s) or other users in the community, freel free to join the Gitter channel:
-
-https://gitter.im/pantab
+If you'd like to chat with the developer(s) or other users in the community, freel free to join the [Hyper API slack channel](https://join.slack.com/t/tableau-datadev/shared_invite/zt-1q4rrimsh-lHHKzrhid1MR4aMOkrnAFQ).
 
 ## Warranty / Consulting
 As dictated by the license, pantab comes without warranty. innobi LLC fortunately offers consulting services and direct support for pantab and on anything which integrates Python and Tableau. Reach out to sales@innobi.io for more details.


### PR DESCRIPTION
The Gitter channel seems to be a dead link
