### PR TITLE
[bug] fix empty read query df

### DIFF
--- a/pantab/_reader.py
+++ b/pantab/_reader.py
@@ -46,7 +46,8 @@ def _read_query_result(
     # Call native library to read tuples from result set
     dtype_strs = tuple(dtypes.values())
     df = pd.DataFrame(libpantab.read_hyper_query(result._Result__cdata, dtype_strs))
-
+    if df.empty:
+        return df
     df.columns = dtypes.keys()
     # TODO: remove this hackery...
     for k, v in dtypes.items():

--- a/pantab/_reader.py
+++ b/pantab/_reader.py
@@ -47,7 +47,7 @@ def _read_query_result(
     dtype_strs = tuple(dtypes.values())
     df = pd.DataFrame(libpantab.read_hyper_query(result._Result__cdata, dtype_strs))
     if df.empty:
-        return df
+        return pd.DataFrame({col: pd.Series(dtype="object") for col in dtypes})
     df.columns = dtypes.keys()
     # TODO: remove this hackery...
     for k, v in dtypes.items():

--- a/pantab/tests/test_reader.py
+++ b/pantab/tests/test_reader.py
@@ -112,3 +112,13 @@ def test_read_query(df, tmp_hyper):
     expected = expected.astype({"i": "Int16", "_i2": "string"})
 
     tm.assert_frame_equal(result, expected)
+
+
+def test_empty_read_query(df, tmp_hyper):
+    """
+    red-green for empty query results
+    """
+    pantab.frame_to_hyper(df, tmp_hyper, table="test")
+    query = "SELECT * FROM test limit 0"
+    result = pantab.frame_from_hyper_query(tmp_hyper, query)
+    assert result.empty


### PR DESCRIPTION
We've also ran into this problem. We believe pantab shouldn't error given an empty df.

As usual this is Red-Green tested... and covered

closes #163 
