### PR TITLE
Jorwoods/cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-11]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.16.2
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,8 +25,7 @@ jobs:
         env:
           CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_SKIP: "*musllinux*"
-          CIBW_TEST_REQUIRES: "pytest distutils"
-          CIBW_TEST_COMMAND: "python -c 'import pantab; pantab.test()'"
+          CIBW_TEST_COMMAND: "pytest"
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_SKIP: "*musllinux*"
+          CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_COMMAND: "pytest"
         # to supply options, put them in 'env', like:
         # env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,6 @@ jobs:
           CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_REQUIRES: "pytest"
-          CIBW_BEFORE_TEST: "pip install pantab"
           CIBW_TEST_COMMAND: "python -c 'import pantab; pantab.test()'"
         # to supply options, put them in 'env', like:
         # env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,6 +25,9 @@ jobs:
         env:
           CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_SKIP: "*musllinux*"
+          CIBW_TEST_REQUIRES: "pytest"
+          CIBW_BEFORE_TEST: "pip install pantab"
+          CIBW_TEST_COMMAND: "python -c 'import pantab; pantab.test()'"
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_SKIP: "*musllinux*"
-          CIBW_TEST_REQUIRES: "pytest"
+          CIBW_TEST_REQUIRES: "pytest distutils"
           CIBW_TEST_COMMAND: "python -c 'import pantab; pantab.test()'"
         # to supply options, put them in 'env', like:
         # env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,6 +7,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macOS-11]
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
           CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_COMMAND: "pytest"
+          CIBW_TEST_COMMAND: "pytest {project}/pantab/tests"
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,6 +24,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp38-*64 cp39-*64 cp310-*64 cp311-*64 cp312-*64"
+          CIBW_SKIP: "*musllinux*"
         # to supply options, put them in 'env', like:
         # env:
         #   CIBW_SOME_OPTION: value

--- a/pantab/_compat.py
+++ b/pantab/_compat.py
@@ -1,8 +1,8 @@
-from distutils.version import LooseVersion
+from packaging.version import parse
 
 import pandas as pd
 
-PANDAS_120 = LooseVersion(pd.__version__) >= LooseVersion("1.2.0")
-PANDAS_130 = LooseVersion(pd.__version__) >= LooseVersion("1.3.0")
+PANDAS_120 = parse(pd.__version__) >= parse("1.2.0")
+PANDAS_130 = parse(pd.__version__) >= parse("1.3.0")
 
 __all__ = ["PANDAS_120", "PANDAS_130"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ requires = ["setuptools", "wheel", "tableauhyperapi", "oldest-supported-numpy"]
 [tool.towncrier]
     package = "pantab"
     filename = "NEWS.rst"
+
+[tool.cibuildwheel]
+build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,8 @@ requires = ["setuptools", "wheel", "tableauhyperapi", "oldest-supported-numpy"]
 
 [tool.cibuildwheel]
 build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "pantab/tests",
+]


### PR DESCRIPTION
- Add CI pipeline to build wheels for all platforms and python versions. 
- Replace deprecated `distutils` reference
- Add pytest configuration to pyproject.toml