### PR TITLE
ci: run pypi publish in correct environment

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -29,7 +29,7 @@ jobs:
   upload_pypi:
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: release
     permissions:
       id-token: write
         #    if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
PyPi publish was configured to use a different environment. Correcting that.