### PR TITLE
Publishing job fixups

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -29,10 +29,12 @@ jobs:
   upload_pypi:
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    environment: release
+    environment:
+      name: release
+      url: https://pypi.org/project/pantab/
     permissions:
       id-token: write
-        #    if: github.event_name == 'release' && github.event.action == 'published'
+    #    if: github.event_name == 'release' && github.event.action == 'published'
     # or, alternatively, upload to PyPI on every tag starting with 'v' (remove on: release above to use this)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
@@ -43,6 +45,5 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://pypi.org/legacy/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
@jorwoods if you don't mind taking a look. I think the environment issue is a red herring. We probably just need to explicitly name the pantab target location we are trying to right to in the job