### PR TITLE
4.0 benchmarks

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -74,6 +74,7 @@
   "matrix": {
     "pandas": [],
     "pip+tableauhyperapi": [],
+    "pyarrow": [],
   },
 
   // Combinations of libraries/python versions can be excluded/included

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from tableauhyperapi import HyperProcess, Telemetry
 
 import pantab
 
@@ -21,7 +20,6 @@ class TimeSuite:
                 True,
                 pd.to_datetime("2018-01-01"),
                 pd.to_datetime("2018-01-01", utc=True),
-                pd.Timedelta("1 days 2 hours 3 minutes 4 seconds"),
                 "foo",
             ]
         ] * nrows
@@ -40,7 +38,6 @@ class TimeSuite:
                 "bool",
                 "datetime64",
                 "datetime64_utc",
-                "timedelta64",
                 "object",
             ],
         )
@@ -55,60 +52,41 @@ class TimeSuite:
                 "bool": bool,
                 "datetime64": "datetime64[ns]",
                 "datetime64_utc": "datetime64[ns, UTC]",
-                "timedelta64": "timedelta64[ns]",
                 "object": "object",
             }
         )
 
         path = "test.hyper"
         pantab.frame_to_hyper(df, path, table="test")
-        self.hyper = HyperProcess(Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU)
 
         return df
 
-    def teardown(self):
-        self.hyper.close()
-
     def time_write_frame(self):
-        pantab.frame_to_hyper(
-            self.df, "dummy.hyper", table="dummy", hyper_process=self.hyper
-        )
+        pantab.frame_to_hyper(self.df, "dummy.hyper", table="dummy")
 
     def time_read_frame(self):
-        pantab.frame_from_hyper("test.hyper", table="test", hyper_process=self.hyper)
+        pantab.frame_from_hyper("test.hyper", table="test")
 
 
 class TimeWriteLong:
     def setup(self):
-        self.hyper = HyperProcess(Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU)
         self.df = pd.DataFrame(np.ones((10_000_000, 1)), columns=["a"])
 
-    def teardown(self):
-        self.hyper.close()
-
     def time_write_frame(self):
-        pantab.frame_to_hyper(
-            self.df, "dummy.hyper", table="dummy", hyper_process=self.hyper
-        )
+        pantab.frame_to_hyper(self.df, "dummy.hyper", table="dummy")
 
     def peakmem_write_frame(self):
-        pantab.frame_to_hyper(
-            self.df, "dummy.hyper", table="dummy", hyper_process=self.hyper
-        )
+        pantab.frame_to_hyper(self.df, "dummy.hyper", table="dummy")
 
 
 class TimeReadLong:
     def setup(self):
         df = pd.DataFrame(np.ones((10_000_000, 1)), columns=["a"])
         path = "test.hyper"
-        self.hyper = HyperProcess(Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU)
-        pantab.frame_to_hyper(df, path, table="test", hyper_process=self.hyper)
-
-    def teardown(self):
-        self.hyper.close()
+        pantab.frame_to_hyper(df, path, table="test")
 
     def time_read_frame(self):
-        pantab.frame_from_hyper("test.hyper", table="test", hyper_process=self.hyper)
+        pantab.frame_from_hyper("test.hyper", table="test")
 
     def peakmem_read_frame(self):
-        pantab.frame_from_hyper("test.hyper", table="test", hyper_process=self.hyper)
+        pantab.frame_from_hyper("test.hyper", table="test")


### PR DESCRIPTION
surprisingly these only show a regression in memory usage for the reader, which may come back to a leak.

I was hoping for a performance boost, but may not be the case. I saw that in the prior design which never had to check `ArrowArrayViewIsNull` during writes; maybe can be tweaked?
