### PR TITLE
Fix leaks

### DIFF
--- a/src/pantab/writer.cpp
+++ b/src/pantab/writer.cpp
@@ -66,12 +66,14 @@ public:
     const struct ArrowSchema *child_schema =
         schema_->children[column_position_];
 
-    if (ArrowArrayViewInitFromSchema(&array_view_, child_schema, error_) != 0) {
+    if (ArrowArrayViewInitFromSchema(array_view_.get(), child_schema, error_) !=
+        0) {
       throw std::runtime_error("Could not construct insert helper: " +
                                std::string{error_->message});
     }
 
-    if (ArrowArrayViewSetArray(&array_view_, chunk_->children[column_position_],
+    if (ArrowArrayViewSetArray(array_view_.get(),
+                               chunk_->children[column_position_],
                                error_) != 0) {
       throw std::runtime_error("Could not set array view: " +
                                std::string{error_->message});
@@ -87,7 +89,7 @@ protected:
   const struct ArrowSchema *schema_;
   struct ArrowError *error_;
   const int64_t column_position_;
-  struct ArrowArrayView array_view_;
+  nanoarrow::UniqueArrayView array_view_;
 };
 
 template <typename T> class IntegralInsertHelper : public InsertHelper {
@@ -95,14 +97,14 @@ public:
   using InsertHelper::InsertHelper;
 
   void InsertValueAtIndex(size_t idx) override {
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<T>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
       return;
     }
 
-    const int64_t value = ArrowArrayViewGetIntUnsafe(&array_view_, idx);
+    const int64_t value = ArrowArrayViewGetIntUnsafe(array_view_.get(), idx);
     hyperapi::internal::ValueInserter{*inserter_}.addValue(
         static_cast<T>(value));
   }
@@ -113,14 +115,14 @@ public:
   using InsertHelper::InsertHelper;
 
   void InsertValueAtIndex(size_t idx) override {
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<T>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
       return;
     }
 
-    const uint64_t value = ArrowArrayViewGetUIntUnsafe(&array_view_, idx);
+    const uint64_t value = ArrowArrayViewGetUIntUnsafe(array_view_.get(), idx);
     hyperapi::internal::ValueInserter{*inserter_}.addValue(
         static_cast<uint32_t>(value));
   }
@@ -131,14 +133,14 @@ public:
   using InsertHelper::InsertHelper;
 
   void InsertValueAtIndex(size_t idx) override {
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<T>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
       return;
     }
 
-    const double value = ArrowArrayViewGetDoubleUnsafe(&array_view_, idx);
+    const double value = ArrowArrayViewGetDoubleUnsafe(array_view_.get(), idx);
     hyperapi::internal::ValueInserter{*inserter_}.addValue(
         static_cast<T>(value));
   }
@@ -149,7 +151,7 @@ public:
   using InsertHelper::InsertHelper;
 
   void InsertValueAtIndex(size_t idx) override {
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<std:::string_view>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
@@ -157,7 +159,7 @@ public:
     }
 
     const struct ArrowBufferView buffer_view =
-        ArrowArrayViewGetBytesUnsafe(&array_view_, idx);
+        ArrowArrayViewGetBytesUnsafe(array_view_.get(), idx);
     const hyperapi::ByteSpan result{
         buffer_view.data.as_uint8, static_cast<size_t>(buffer_view.size_bytes)};
     hyperapi::internal::ValueInserter{*inserter_}.addValue(result);
@@ -169,7 +171,7 @@ public:
   using InsertHelper::InsertHelper;
 
   void InsertValueAtIndex(size_t idx) override {
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<std:::string_view>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
@@ -177,7 +179,7 @@ public:
     }
 
     const struct ArrowBufferView buffer_view =
-        ArrowArrayViewGetBytesUnsafe(&array_view_, idx);
+        ArrowArrayViewGetBytesUnsafe(array_view_.get(), idx);
 #if defined(_WIN32) && defined(_MSC_VER)
     const auto result = std::string{
         buffer_view.data.as_char, static_cast<size_t>(buffer_view.size_bytes)};
@@ -195,7 +197,7 @@ public:
 
   void InsertValueAtIndex(size_t idx) override {
     constexpr size_t elem_size = sizeof(int32_t);
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<timestamp_t>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
@@ -204,7 +206,7 @@ public:
 
     int32_t value;
     memcpy(&value,
-           array_view_.buffer_views[1].data.as_uint8 + (idx * elem_size),
+           array_view_->buffer_views[1].data.as_uint8 + (idx * elem_size),
            elem_size);
 
     const std::chrono::duration<int32_t, std::ratio<86400>> dur{value};
@@ -228,14 +230,14 @@ public:
   using InsertHelper::InsertHelper;
 
   void InsertValueAtIndex(size_t idx) override {
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<T>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
       return;
     }
 
-    int64_t value = ArrowArrayViewGetIntUnsafe(&array_view_, idx);
+    int64_t value = ArrowArrayViewGetIntUnsafe(array_view_.get(), idx);
     // TODO: check for overflow in these branches
     if constexpr (TU == NANOARROW_TIME_UNIT_SECOND) {
       value *= 1'000'000;
@@ -255,7 +257,7 @@ public:
 
   void InsertValueAtIndex(size_t idx) override {
     constexpr size_t elem_size = sizeof(int64_t);
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<timestamp_t>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
@@ -264,7 +266,7 @@ public:
 
     int64_t value;
     memcpy(&value,
-           array_view_.buffer_views[1].data.as_uint8 + (idx * elem_size),
+           array_view_->buffer_views[1].data.as_uint8 + (idx * elem_size),
            elem_size);
 
     // using timestamp_t =
@@ -314,7 +316,7 @@ public:
   using InsertHelper::InsertHelper;
 
   void InsertValueAtIndex(size_t idx) override {
-    if (ArrowArrayViewIsNull(&array_view_, idx)) {
+    if (ArrowArrayViewIsNull(array_view_.get(), idx)) {
       // MSVC on cibuildwheel doesn't like this templated optional
       // inserter_->add(std::optional<timestamp_t>{std::nullopt});
       hyperapi::internal::ValueInserter{*inserter_}.addNull();
@@ -323,7 +325,7 @@ public:
 
     struct ArrowInterval arrow_interval;
     ArrowIntervalInit(&arrow_interval, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
-    ArrowArrayViewGetIntervalUnsafe(&array_view_, idx, &arrow_interval);
+    ArrowArrayViewGetIntervalUnsafe(array_view_.get(), idx, &arrow_interval);
     const auto usec = static_cast<int32_t>(arrow_interval.ns / 1000);
 
     // Hyper has no template specialization to insert an interval; instead we


### PR DESCRIPTION
closes #268 

Using this MRE:

```python
import numpy as np
import pandas as pd
import pantab as pt


df = pd.DataFrame(np.random.randn(100_000, 10), columns=list('abcdefghij'))
for _ in range(10):
    pt.frame_to_hyper(df, "example.hyper", table="table", table_mode="a")
```

And running under valgrind:

```
valgrind --tool=memcheck --leak-check=full python check_leak.py
```

main was showing the following leak (not sure why bytes are 0) which this PR fixes

```
==257006== HEAP SUMMARY:
==257006==     in use at exit: 7,024,540 bytes in 8,087 blocks
==257006==   total heap usage: 125,712 allocs, 117,625 frees, 630,341,030 bytes allocated
==257006== 
==257006== 0 bytes in 100 blocks are definitely lost in loss record 1 of 1,685
==257006==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==257006==    by 0x745FC062: ArrowMalloc (utils.c:186)
==257006==    by 0x745F4C00: ArrowArrayViewAllocateChildren (array.c:499)
==257006==    by 0x745F4E5C: ArrowArrayViewInitFromSchema (array.c:549)
==257006==    by 0x745B6320: InsertHelper::InsertHelper(std::shared_ptr<hyperapi::Inserter>, ArrowArray const*, ArrowSchema const*, ArrowError*, long) (writer.cpp:69)
==257006==    by 0x745BA6FB: FloatingInsertHelper<double>::InsertHelper(std::shared_ptr<hyperapi::Inserter>, ArrowArray const*, ArrowSchema const*, ArrowError*, long) (writer.cpp:131)
==257006==    by 0x745BA7CE: std::_MakeUniq<FloatingInsertHelper<double> >::__single_object std::make_unique<FloatingInsertHelper<double>, std::shared_ptr<hyperapi::Inserter>&, ArrowArray*&, ArrowSchema*&, ArrowError*&, long&>(std::shared_ptr<hyperapi::Inserter>&, ArrowArray*&, ArrowSchema*&, ArrowError*&, long&) (unique_ptr.h:962)
==257006==    by 0x745ADFEB: MakeInsertHelper(std::shared_ptr<hyperapi::Inserter>, ArrowArray*, ArrowSchema*, ArrowError*, long) (writer.cpp:374)
==257006==    by 0x745B03C7: write_to_hyper(std::map<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, nanobind::capsule, 
==257006== 
```