### PR TITLE
More clang-tidy cleanups in writer.cpp

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-*,cppcoreguidelines-*,-cppcoreguidelines-pro-type-union-access'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,8 +11,24 @@ jobs:
   code-checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: pre-commit/action@v3.0.0
+
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - name: Install nanobind
+      run: python -m pip install nanobind
+    - name: Build project
+      run: |
+        cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        cmake --build build
+        ln -s build/compile_commands.json
+    - name: Run clang-tidy
+      run: |
+        clang-tidy src/pantab/writer.cpp
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/src/pantab/writer.cpp
+++ b/src/pantab/writer.cpp
@@ -105,9 +105,7 @@ protected:
   }
 
   template <typename T> auto InsertNull() {
-    // MSVC on cibuildwheel doesn't like this templated optional
-    // inserter_->add(std::optional<std:::string_view>{std::nullopt});
-    inserter_.add(std::optional<T>{});
+    inserter_.add(hyperapi::optional<T>{});
   }
 
   auto GetArrayView() const { return array_view_.get(); }


### PR DESCRIPTION
following guideline to not use protected members in subclasses

closer to clean with 

```
clang-tidy src/pantab/writer.cpp "-checks=-*,cppcoreguidelines-*"
```