### PR TITLE
Fix mypy checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ pre-commit
 New code development should come bundled with type annotations. Be sure to check any new annotations with
 
 ```sh
-mypy pantab
+mypy src/
 ```
 
 ### Adding a whatsnew entry

--- a/src/pantab/libpantab.pyi
+++ b/src/pantab/libpantab.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 def write_to_hyper(
     dict_of_capsules: dict[tuple[str, str], Any],
@@ -7,5 +7,12 @@ def write_to_hyper(
     not_null_columns: set[str],
     json_columns: set[str],
     geo_columns: set[str],
+    process_params: Optional[dict[str, str]],
 ) -> None: ...
-def read_from_hyper_query(path: str, query: str): ...
+def read_from_hyper_query(
+    path: str,
+    query: str,
+    process_params: Optional[dict[str, str]],
+) -> Any: ...
+def escape_sql_identifier(str: str) -> str: ...
+def get_table_names(path: str) -> list[str]: ...


### PR DESCRIPTION
Before:
```
(pantab-dev) @Priyansh121096 ➜ /workspaces/pantab (fix-mypy) $ mypy src/
src/pantab/_writer.py:102: error: "TableauName" has no attribute "name"  [attr-defined]
src/pantab/_writer.py:115: error: Unexpected keyword argument "process_params" for "write_to_hyper"  [call-arg]
src/pantab/libpantab.pyi:3: note: "write_to_hyper" defined here
src/pantab/_reader.py:22: error: Too many arguments for "read_from_hyper_query"  [call-arg]
src/pantab/_reader.py:55: error: Module has no attribute "escape_sql_identifier"  [attr-defined]
src/pantab/_reader.py:71: error: Module has no attribute "get_table_names"  [attr-defined]
Found 5 errors in 2 files (checked 5 source files)
```

After:
```
(pantab-dev) @Priyansh121096 ➜ /workspaces/pantab (fix-mypy) $ mypy src/
src/pantab/_writer.py:102: error: "TableauName" has no attribute "name"  [attr-defined]
Found 1 error in 1 file (checked 5 source files)
```

@WillAyd The remaining error looks like either a bug at `_writer.py:102` or an issue with the protocols in `_types.py`. Can you confirm which is the case? 

Also, maybe we can use something like https://github.com/cansik/nanobind-stubgen to automatically generate the `libpantab.pyi` stub file?