### PR TITLE
Bump nanobind dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "scikit-build-core",
-  "nanobind",
+  "nanobind>=2.2.0",
 ]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
looks like there is an ASAN violation in nanobind < 2.2 trying to dereference a nullptr in the nb_func module