### PR TITLE
Refactor C++ sources: fix bugs, reduce duplication, improve consistency

### DIFF
--- a/src/pantab/hyper_process.hpp
+++ b/src/pantab/hyper_process.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <hyperapi/hyperapi.hpp>
+
+static inline auto
+MakeHyperProcess(std::unordered_map<std::string, std::string> process_params)
+    -> hyperapi::HyperProcess {
+  process_params.emplace("log_config", "");
+  process_params.emplace("default_database_version", "2");
+  return hyperapi::HyperProcess{
+      hyperapi::Telemetry::DoNotSendUsageDataToTableau, "",
+      std::move(process_params)};
+}

--- a/src/pantab/libpantab.cpp
+++ b/src/pantab/libpantab.cpp
@@ -4,6 +4,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/vector.h>
 
+#include "hyper_process.hpp"
 #include "reader.hpp"
 #include "writer.hpp"
 
@@ -22,11 +23,7 @@ NB_MODULE(libpantab, m) { // NOLINT
       .def(
           "get_table_names",
           [](const std::string &path) {
-            std::unordered_map<std::string, std::string> params{
-                {"log_config", ""}};
-            const hyperapi::HyperProcess hyper{
-                hyperapi::Telemetry::DoNotSendUsageDataToTableau, "",
-                std::move(params)};
+            auto hyper = MakeHyperProcess({});
             hyperapi::Connection connection(hyper.getEndpoint(), path);
 
             nb::list result;

--- a/src/pantab/numeric_gen.hpp
+++ b/src/pantab/numeric_gen.hpp
@@ -2,8 +2,12 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <variant>
+
+inline constexpr int32_t kMaxNumericPrecision = 38;
+inline constexpr int32_t kNumericVariantSize = kMaxNumericPrecision + 1; // 39
 
 // The Tableau Hyper API requires Numeric to be templated at compile time
 // but the values are only known at runtime. This solution is adopted from

--- a/src/pantab/reader.cpp
+++ b/src/pantab/reader.cpp
@@ -1,7 +1,9 @@
 #include "reader.hpp"
+#include "hyper_process.hpp"
 #include "numeric_gen.hpp"
 
 #include <span>
+#include <stdexcept>
 #include <variant>
 #include <vector>
 
@@ -23,9 +25,19 @@ public:
   ReadHelper &operator=(ReadHelper &&) = delete;
 
   virtual ~ReadHelper() = default;
-  virtual auto Read(const hyperapi::Value &) -> void = 0;
+
+  auto Read(const hyperapi::Value &value) -> void {
+    if (value.isNull()) {
+      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
+        throw std::runtime_error("ArrowArrayAppendNull failed");
+      }
+      return;
+    }
+    ReadNonNull(value);
+  }
 
 protected:
+  virtual auto ReadNonNull(const hyperapi::Value &) -> void = 0;
   auto GetMutableArray() { return array_; }
 
 private:
@@ -35,13 +47,7 @@ private:
 template <typename T> class IntegralReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     if (ArrowArrayAppendInt(GetMutableArray(), value.get<T>())) {
       throw std::runtime_error("ArrowAppendInt failed");
     };
@@ -51,13 +57,7 @@ template <typename T> class IntegralReadHelper : public ReadHelper {
 class OidReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     if (ArrowArrayAppendUInt(GetMutableArray(), value.get<uint32_t>())) {
       throw std::runtime_error("ArrowAppendUInt failed");
     };
@@ -67,13 +67,7 @@ class OidReadHelper : public ReadHelper {
 template <typename T> class FloatReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     if (ArrowArrayAppendDouble(GetMutableArray(), value.get<T>())) {
       throw std::runtime_error("ArrowAppendDouble failed");
     };
@@ -83,13 +77,7 @@ template <typename T> class FloatReadHelper : public ReadHelper {
 class BooleanReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     if (ArrowArrayAppendInt(GetMutableArray(), value.get<bool>())) {
       throw std::runtime_error("ArrowAppendBool failed");
     };
@@ -99,14 +87,7 @@ class BooleanReadHelper : public ReadHelper {
 class BytesReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
-
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     // TODO: we can use the non-owning hyperapi::ByteSpan template type but
     // there is a bug in that header file that needs an upstream fix first
     const auto bytes = value.get<std::vector<uint8_t>>();
@@ -114,7 +95,7 @@ class BytesReadHelper : public ReadHelper {
                                             static_cast<int64_t>(bytes.size())};
 
     if (ArrowArrayAppendBytes(GetMutableArray(), arrow_buffer_view)) {
-      throw std::runtime_error("ArrowAppendString failed");
+      throw std::runtime_error("ArrowArrayAppendBytes failed");
     };
   }
 };
@@ -122,14 +103,7 @@ class BytesReadHelper : public ReadHelper {
 class StringReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
-
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
 #if defined(_WIN32) && defined(_MSC_VER)
     const auto strval = value.get<std::string>();
     const ArrowStringView arrow_string_view{
@@ -149,14 +123,7 @@ class StringReadHelper : public ReadHelper {
 class DateReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
-
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     // TODO: need some bounds /overflow checking
     // tableau uses uint32 but we have int32
     constexpr int32_t tableau_to_unix_days = 2440588;
@@ -181,14 +148,7 @@ class DateReadHelper : public ReadHelper {
 template <bool TZAware> class DatetimeReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
-
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     using timestamp_t =
         typename std::conditional<TZAware, hyperapi::OffsetTimestamp,
                                   hyperapi::Timestamp>::type;
@@ -219,14 +179,7 @@ template <bool TZAware> class DatetimeReadHelper : public ReadHelper {
 class TimeReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
-
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     const auto time = value.get<hyperapi::Time>();
     const auto raw_value = time.getRaw();
     if (ArrowArrayAppendInt(GetMutableArray(),
@@ -239,14 +192,7 @@ class TimeReadHelper : public ReadHelper {
 class IntervalReadHelper : public ReadHelper {
   using ReadHelper::ReadHelper;
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
-
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     struct ArrowInterval arrow_interval {};
     ArrowIntervalInit(&arrow_interval, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
     const auto interval_value = value.get<hyperapi::Interval>();
@@ -276,23 +222,15 @@ public:
                              int32_t scale)
       : ReadHelper(array), precision_(precision), scale_(scale) {}
 
-  auto Read(const hyperapi::Value &value) -> void override {
-    if (value.isNull()) {
-      if (ArrowArrayAppendNull(GetMutableArray(), 1)) {
-        throw std::runtime_error("ArrowAppendNull failed");
-      }
-      return;
-    }
-
+  auto ReadNonNull(const hyperapi::Value &value) -> void override {
     constexpr int32_t bitwidth = 128;
     struct ArrowDecimal decimal {};
     ArrowDecimalInit(&decimal, bitwidth, precision_, scale_);
 
-    constexpr auto PrecisionLimit = 39; // of-by-one error in solution?
-    if (precision_ >= PrecisionLimit) {
+    if (precision_ > kMaxNumericPrecision) {
       throw nb::value_error("Numeric precision may not exceed 38!");
     }
-    if (scale_ >= PrecisionLimit) {
+    if (scale_ > kMaxNumericPrecision) {
       throw nb::value_error("Numeric scale may not exceed 38!");
     }
 
@@ -304,10 +242,10 @@ public:
             std::erase(value_string, '.');
             return value_string;
           }
-          throw "unreachable";
+          throw std::logic_error("unreachable: scale > precision");
         },
-        to_integral_variant<PrecisionLimit>(precision_),
-        to_integral_variant<PrecisionLimit>(scale_));
+        to_integral_variant<kNumericVariantSize>(precision_),
+        to_integral_variant<kNumericVariantSize>(scale_));
 
     const struct ArrowStringView sv {
       decimal_string.data(), static_cast<int64_t>(decimal_string.size())
@@ -370,7 +308,7 @@ static auto MakeReadHelper(const ArrowSchemaView *schema_view,
         new DecimalReadHelper(array, precision, scale));
   }
   default:
-    throw nb::type_error("unknownn arrow type provided");
+    throw nb::type_error("unknown arrow type provided");
   }
 }
 
@@ -587,16 +525,7 @@ auto read_from_hyper_query(
     std::unordered_map<std::string, std::string> &&process_params,
     size_t chunk_size) -> nb::capsule {
 
-  if (!process_params.count("log_config")) {
-    process_params["log_config"] = "";
-  } else {
-    process_params.erase("log_config");
-  }
-  if (!process_params.count("default_database_version"))
-    process_params["default_database_version"] = "2";
-
-  hyperapi::HyperProcess hyper{hyperapi::Telemetry::DoNotSendUsageDataToTableau,
-                               "", std::move(process_params)};
+  auto hyper = MakeHyperProcess(std::move(process_params));
   hyperapi::Connection connection(hyper.getEndpoint(), path);
 
   if (chunk_size) {

--- a/src/pantab/writer.cpp
+++ b/src/pantab/writer.cpp
@@ -1,4 +1,5 @@
 #include "writer.hpp"
+#include "hyper_process.hpp"
 #include "numeric_gen.hpp"
 
 #include <hyperapi/hyperapi.hpp>
@@ -7,6 +8,7 @@
 #include <chrono>
 #include <set>
 #include <span>
+#include <stdexcept>
 #include <utility>
 #include <variant>
 
@@ -420,11 +422,10 @@ public:
         precision_(precision), scale_(scale) {}
 
   void InsertValueAtIndex(int64_t idx) override {
-    constexpr auto PrecisionLimit = 39; // of-by-one error in solution?
-    if (precision_ >= PrecisionLimit) {
+    if (precision_ > kMaxNumericPrecision) {
       throw nb::value_error("Numeric precision may not exceed 38!");
     }
-    if (scale_ >= PrecisionLimit) {
+    if (scale_ > kMaxNumericPrecision) {
       throw nb::value_error("Numeric scale may not exceed 38!");
     }
 
@@ -435,11 +436,11 @@ public:
               InsertNull<hyperapi::Numeric<P(), S()>>();
               return;
             } else {
-              throw "unreachable";
+              throw std::logic_error("unreachable: scale > precision");
             }
           },
-          to_integral_variant<PrecisionLimit>(precision_),
-          to_integral_variant<PrecisionLimit>(scale_));
+          to_integral_variant<kNumericVariantSize>(precision_),
+          to_integral_variant<kNumericVariantSize>(scale_));
       return;
     }
 
@@ -482,11 +483,11 @@ public:
             InsertValue(std::move(value));
             return;
           } else {
-            throw "unreachable";
+            throw std::logic_error("unreachable: scale > precision");
           }
         },
-        to_integral_variant<PrecisionLimit>(precision_),
-        to_integral_variant<PrecisionLimit>(scale_));
+        to_integral_variant<kNumericVariantSize>(precision_),
+        to_integral_variant<kNumericVariantSize>(scale_));
 
     ArrowBufferReset(&buffer);
   }
@@ -515,6 +516,21 @@ public:
     InsertValue(std::move(result));
   }
 };
+
+template <enum ArrowTimeUnit TU>
+static auto MakeTimestampInsertHelper(hyperapi::Inserter &inserter,
+                                      struct ArrowArray *chunk,
+                                      const struct ArrowSchema *child_schema,
+                                      struct ArrowError *error,
+                                      int64_t column_position, bool tz_aware)
+    -> std::unique_ptr<InsertHelper> {
+  if (tz_aware)
+    return std::make_unique<TimestampInsertHelper<TU, true>>(
+        inserter, chunk, child_schema, error, column_position);
+  else
+    return std::make_unique<TimestampInsertHelper<TU, false>>(
+        inserter, chunk, child_schema, error, column_position);
+}
 
 static auto MakeInsertHelper(hyperapi::Inserter &inserter,
                              struct ArrowArray *chunk,
@@ -563,51 +579,25 @@ static auto MakeInsertHelper(hyperapi::Inserter &inserter,
   case NANOARROW_TYPE_DATE32:
     return std::make_unique<Date32InsertHelper>(inserter, chunk, child_schema,
                                                 error, column_position);
-  case NANOARROW_TYPE_TIMESTAMP:
+  case NANOARROW_TYPE_TIMESTAMP: {
+    const bool tz_aware = std::strcmp("", schema_view.timezone);
     switch (schema_view.time_unit) {
     case NANOARROW_TIME_UNIT_SECOND:
-      if (std::strcmp("", schema_view.timezone)) {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_SECOND, true>>(
-            inserter, chunk, child_schema, error, column_position);
-      } else {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_SECOND, false>>(
-            inserter, chunk, child_schema, error, column_position);
-      }
+      return MakeTimestampInsertHelper<NANOARROW_TIME_UNIT_SECOND>(
+          inserter, chunk, child_schema, error, column_position, tz_aware);
     case NANOARROW_TIME_UNIT_MILLI:
-      if (std::strcmp("", schema_view.timezone)) {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_MILLI, true>>(
-            inserter, chunk, child_schema, error, column_position);
-      } else {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_MILLI, false>>(
-            inserter, chunk, child_schema, error, column_position);
-      }
+      return MakeTimestampInsertHelper<NANOARROW_TIME_UNIT_MILLI>(
+          inserter, chunk, child_schema, error, column_position, tz_aware);
     case NANOARROW_TIME_UNIT_MICRO:
-      if (std::strcmp("", schema_view.timezone)) {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_MICRO, true>>(
-            inserter, chunk, child_schema, error, column_position);
-      } else {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_MICRO, false>>(
-            inserter, chunk, child_schema, error, column_position);
-      }
+      return MakeTimestampInsertHelper<NANOARROW_TIME_UNIT_MICRO>(
+          inserter, chunk, child_schema, error, column_position, tz_aware);
     case NANOARROW_TIME_UNIT_NANO:
-      if (std::strcmp("", schema_view.timezone)) {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_NANO, true>>(
-            inserter, chunk, child_schema, error, column_position);
-      } else {
-        return std::make_unique<
-            TimestampInsertHelper<NANOARROW_TIME_UNIT_NANO, false>>(
-            inserter, chunk, child_schema, error, column_position);
-      }
+      return MakeTimestampInsertHelper<NANOARROW_TIME_UNIT_NANO>(
+          inserter, chunk, child_schema, error, column_position, tz_aware);
     }
     throw std::runtime_error(
         "This code block should not be hit - contact a developer");
+  }
   case NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO:
     return std::make_unique<IntervalInsertHelper>(inserter, chunk, child_schema,
                                                   error, column_position);
@@ -743,17 +733,7 @@ void write_to_hyper(
     geo_set.insert(colstr);
   }
 
-  if (!process_params.count("log_config")) {
-    process_params["log_config"] = "";
-  } else {
-    process_params.erase("log_config");
-  }
-  if (!process_params.count("default_database_version"))
-    process_params["default_database_version"] = "2";
-
-  const hyperapi::HyperProcess hyper{
-      hyperapi::Telemetry::DoNotSendUsageDataToTableau, "",
-      std::move(process_params)};
+  auto hyper = MakeHyperProcess(std::move(process_params));
 
   // TODO: we don't have separate table / database create modes in the API
   // but probably should; for now we infer this from table mode


### PR DESCRIPTION
- Fix log_config erasure bug: process_params.erase() was deleting user-provided log_config values instead of keeping them. Replaced with emplace() semantics.
- Extract MakeHyperProcess() helper into hyper_process.hpp to deduplicate HyperProcess setup across reader.cpp, writer.cpp, and libpantab.cpp.
- Fix throw "unreachable" (const char*) to throw std::logic_error, making exceptions catchable as std::exception.
- Fix typo "unknownn" -> "unknown" in error message and fix misleading "ArrowAppendString failed" in BytesReadHelper.
- Extract PrecisionLimit constant as kMaxNumericPrecision/kNumericVariantSize in numeric_gen.hpp, replacing 3 duplicated magic number definitions.
- Refactor ReadHelper to use template method pattern: null checking is now handled once in the base class Read() method, with subclasses overriding ReadNonNull() instead. Eliminates ~60 lines of duplicated null checks.
- Deduplicate timestamp switch in MakeInsertHelper via MakeTimestampInsertHelper template helper, reducing 8 near-identical branches to 4 one-line calls.

closes #xxx
