### PR TITLE
Replace std::variant/visit with function pointer table dispatch for faster compilation

### DIFF
--- a/src/pantab/numeric_gen.hpp
+++ b/src/pantab/numeric_gen.hpp
@@ -3,16 +3,22 @@
 #include <array>
 #include <cstddef>
 #include <utility>
-#include <variant>
 
 // The Tableau Hyper API requires Numeric to be templated at compile time
-// but the values are only known at runtime. This solution is adopted from
-// https://stackoverflow.com/questions/78888913/creating-cartesian-product-from-integer-range-template-argument/78889229?noredirect=1#comment139097273_78889229
-template <std::size_t N> constexpr auto to_integral_variant(std::size_t n) {
-  return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-    using ResType = std::variant<std::integral_constant<std::size_t, Is>...>;
-    std::array<ResType, N> all{
-        ResType{std::integral_constant<std::size_t, Is>{}}...};
-    return all[n];
-  }(std::make_index_sequence<N>());
+// but the values are only known at runtime. This dispatches a runtime index
+// n ∈ [0, N) to a compile-time integral_constant, calling f with it.
+//
+// Uses a function pointer table for O(1) dispatch. This replaces the previous
+// std::variant + std::visit approach which was extremely slow to compile due
+// to the cartesian product of two N-element variant visit dispatch tables.
+template <std::size_t N, typename F>
+constexpr void integral_dispatch(std::size_t n, F &&f) {
+  [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+    using FnPtr = void (*)(F &);
+    const std::array<FnPtr, N> table{
+        {static_cast<FnPtr>([](F &fn) {
+          fn(std::integral_constant<std::size_t, Is>{});
+        })...}};
+    table[n](f);
+  }(std::make_index_sequence<N>{});
 }

--- a/src/pantab/reader.cpp
+++ b/src/pantab/reader.cpp
@@ -2,7 +2,6 @@
 #include "numeric_gen.hpp"
 
 #include <span>
-#include <variant>
 #include <vector>
 
 #include <hyperapi/hyperapi.hpp>
@@ -296,18 +295,19 @@ public:
       throw nb::value_error("Numeric scale may not exceed 38!");
     }
 
-    const auto decimal_string = std::visit(
-        [&value](auto P, auto S) -> std::string {
+    const auto decimal_string = [&]() -> std::string {
+      std::string result;
+      integral_dispatch<PrecisionLimit>(precision_, [&](auto P) {
+        integral_dispatch<PrecisionLimit>(scale_, [&](auto S) {
           if constexpr (S() <= P()) {
             const auto decimal_value = value.get<hyperapi::Numeric<P(), S()>>();
-            auto value_string = decimal_value.toString();
-            std::erase(value_string, '.');
-            return value_string;
+            result = decimal_value.toString();
+            std::erase(result, '.');
           }
-          throw "unreachable";
-        },
-        to_integral_variant<PrecisionLimit>(precision_),
-        to_integral_variant<PrecisionLimit>(scale_));
+        });
+      });
+      return result;
+    }();
 
     const struct ArrowStringView sv {
       decimal_string.data(), static_cast<int64_t>(decimal_string.size())

--- a/src/pantab/writer.cpp
+++ b/src/pantab/writer.cpp
@@ -8,7 +8,6 @@
 #include <set>
 #include <span>
 #include <utility>
-#include <variant>
 
 static auto GetHyperTypeFromArrowSchema(struct ArrowSchema *schema,
                                         ArrowError *error)
@@ -429,17 +428,13 @@ public:
     }
 
     if (CheckNull(idx)) {
-      std::visit(
-          [&](auto P, auto S) {
-            if constexpr (S() <= P()) {
-              InsertNull<hyperapi::Numeric<P(), S()>>();
-              return;
-            } else {
-              throw "unreachable";
-            }
-          },
-          to_integral_variant<PrecisionLimit>(precision_),
-          to_integral_variant<PrecisionLimit>(scale_));
+      integral_dispatch<PrecisionLimit>(precision_, [&](auto P) {
+        integral_dispatch<PrecisionLimit>(scale_, [&](auto S) {
+          if constexpr (S() <= P()) {
+            InsertNull<hyperapi::Numeric<P(), S()>>();
+          }
+        });
+      });
       return;
     }
 
@@ -475,18 +470,14 @@ public:
       }
     }
 
-    std::visit(
-        [&](auto P, auto S) {
-          if constexpr (S() <= P()) {
-            const auto value = hyperapi::Numeric<P(), S()>{str};
-            InsertValue(std::move(value));
-            return;
-          } else {
-            throw "unreachable";
-          }
-        },
-        to_integral_variant<PrecisionLimit>(precision_),
-        to_integral_variant<PrecisionLimit>(scale_));
+    integral_dispatch<PrecisionLimit>(precision_, [&](auto P) {
+      integral_dispatch<PrecisionLimit>(scale_, [&](auto S) {
+        if constexpr (S() <= P()) {
+          const auto value = hyperapi::Numeric<P(), S()>{str};
+          InsertValue(std::move(value));
+        }
+      });
+    });
 
     ArrowBufferReset(&buffer);
   }


### PR DESCRIPTION
The previous approach created two 39-element `std::variant` types and used `std::visit` to dispatch on their cartesian product (39² = 1521 combinations per call site, 3 sites total). `std::visit` is notoriously compile-time heavy due to its internal dispatch table generation and type deduction.

This replaces it with `integral_dispatch`, which builds a `std::array` of function pointers for O(1) runtime dispatch without any variant machinery. Each stateless lambda converts directly to a function pointer. The nested two-level dispatch generates the same template instantiations but avoids the compile-time cost of variant construction and visit table generation.

### Changes
- **`numeric_gen.hpp`**: Replace `to_integral_variant` (variant + array construction) with `integral_dispatch` (function pointer table + direct index)
- **`reader.cpp`**: Convert `std::visit` call to nested `integral_dispatch` calls
- **`writer.cpp`**: Convert both `std::visit` calls to nested `integral_dispatch` calls
- Remove `<variant>` includes from all three files